### PR TITLE
Insert header only if token is available (FIx connect Error)

### DIFF
--- a/src/clients/errors.rs
+++ b/src/clients/errors.rs
@@ -1,5 +1,4 @@
-use golem_client::api::TemplateError;
-use golem_client::api::WorkerError;
+use golem_client::api::{TemplateError, WorkerError};
 
 pub trait ResponseContentErrorMapper {
     fn map(self) -> String;

--- a/src/clients/template.rs
+++ b/src/clients/template.rs
@@ -1,20 +1,10 @@
 use std::io::Read;
 
 use async_trait::async_trait;
-use golem_client::model::Export;
-use golem_client::model::ExportFunction;
-use golem_client::model::ExportInstance;
-use golem_client::model::FunctionParameter;
-use golem_client::model::FunctionResult;
-use golem_client::model::NameOptionTypePair;
-use golem_client::model::NameTypePair;
-use golem_client::model::Template;
-use golem_client::model::Type;
-use golem_client::model::TypeEnum;
-use golem_client::model::TypeFlags;
-use golem_client::model::TypeRecord;
-use golem_client::model::TypeTuple;
-use golem_client::model::TypeVariant;
+use golem_client::model::{
+    Export, ExportFunction, ExportInstance, FunctionParameter, FunctionResult, NameOptionTypePair,
+    NameTypePair, Template, Type, TypeEnum, TypeFlags, TypeRecord, TypeTuple, TypeVariant,
+};
 use serde::Serialize;
 use tokio::fs::File;
 use tracing::info;

--- a/src/clients/worker.rs
+++ b/src/clients/worker.rs
@@ -2,12 +2,10 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use futures_util::{future, pin_mut, SinkExt, StreamExt};
-use golem_client::model::CallingConvention;
-use golem_client::model::InvokeParameters;
-use golem_client::model::InvokeResult;
-use golem_client::model::VersionedWorkerId;
-use golem_client::model::WorkerCreationRequest;
-use golem_client::model::WorkerMetadata;
+use golem_client::model::{
+    CallingConvention, InvokeParameters, InvokeResult, VersionedWorkerId, WorkerCreationRequest,
+    WorkerMetadata,
+};
 use golem_client::Context;
 use native_tls::TlsConnector;
 use serde::Deserialize;
@@ -249,12 +247,13 @@ impl<C: golem_client::api::WorkerClient + Sync + Send> WorkerClient for WorkerCl
             .into_client_request()
             .map_err(|e| GolemError(format!("Can't create request: {e}")))?;
         let headers = request.headers_mut();
-        headers.insert(
-            "Authorization",
-            format!("Bearer {}", self.context.bearer_token().unwrap())
-                .parse()
-                .unwrap(),
-        );
+
+        if let Some(token) = self.context.bearer_token() {
+            headers.insert(
+                "Authorization",
+                format!("Bearer {}", token).parse().unwrap(),
+            );
+        }
 
         let connector = if self.allow_insecure {
             Some(Connector::NativeTls(


### PR DESCRIPTION
The connect doesn't work with golem-cli due to this minor issue, which is fixed. 

The error was

```scala
thread 'main' panicked at .../cargo/registry/src/index.crates.io-6f17d22bba15001f/golem-cli-0.0.13/src/clients/worker.rs:254:62:
called `Option::unwrap()` on a `None` value
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Note that for some logical GolemError, we are still having issues propagating it back to the user - such as , passing non existing worker-id when connecting, results in

```

thread 'main' panicked at src/clients/worker.rs:296:21:
Error reading message: WebSocket protocol error: Connection reset without closing handshake
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

This, I think, needs more debugging for why it is not responding the GolemError.

```scala
 [golem-cloud-server-oss/src/api/worker_connect.rs:52] err = ConnectError(
golem-cloud-server-oss_1     |     "Worker not found: a5b82d36-3445-4fab-bab9-23a683bf45fd/myworker",
golem-cloud-server-oss_1     | )
```