### PR TITLE
Allow websocket connection closure to emit errors, and fix confusing messages in the event of closure

### DIFF
--- a/src/clients/worker.rs
+++ b/src/clients/worker.rs
@@ -305,13 +305,13 @@ impl<C: golem_client::api::WorkerClient + Sync + Send> WorkerClient for WorkerCl
             }
         });
 
-        let read_res = read.for_each(|message| async {
-            match message {
-                Err(e) => {
-                    print!("Error reading message: {}", e);
+        let read_res = read.for_each(|message_or_error| async {
+            match message_or_error {
+                Err(error) => {
+                    print!("Error reading message: {}", error);
                 }
-                Ok(msgg) => {
-                    let msg = match msgg {
+                Ok(message) => {
+                    let instance_connect_msg = match message {
                         Message::Text(str) => {
                             let parsed: serde_json::Result<InstanceConnectMessage> =
                                 serde_json::from_str(&str);
@@ -347,7 +347,7 @@ impl<C: golem_client::api::WorkerClient + Sync + Send> WorkerClient for WorkerCl
                         }
                     };
 
-                    match msg {
+                    match instance_connect_msg {
                         None => {}
                         Some(msg) => match msg.event {
                             WorkerEvent::Stdout(StdOutLog { message }) => {

--- a/src/clients/worker.rs
+++ b/src/clients/worker.rs
@@ -306,58 +306,71 @@ impl<C: golem_client::api::WorkerClient + Sync + Send> WorkerClient for WorkerCl
         });
 
         let read_res = read.for_each(|message| async {
-            let message: Message = message.unwrap();
+            match message {
+                Err(e) => {
+                    print!("Error reading message: {}", e);
+                    return;
+                }
+                Ok(msgg) => {
+                    let msg = match msgg {
+                        Message::Text(str) => {
+                            let parsed: serde_json::Result<InstanceConnectMessage> =
+                                serde_json::from_str(&str);
+                            Some(parsed.unwrap()) // TODO: error handling
+                        }
+                        Message::Binary(data) => {
+                            let parsed: serde_json::Result<InstanceConnectMessage> =
+                                serde_json::from_slice(&data);
+                            Some(parsed.unwrap()) // TODO: error handling
+                        }
+                        Message::Ping(_) => {
+                            debug!("Ignore ping");
+                            None
+                        }
+                        Message::Pong(_) => {
+                            debug!("Ignore pong");
+                            None
+                        }
+                        Message::Close(details) => {
+                            match details {
+                                Some(closed_frame) => {
+                                    print!("Connection Closed: {}", closed_frame);
+                                }
+                                None => {
+                                    print!("Connection Closed");
+                                }
+                            }
+                            None
+                        }
+                        Message::Frame(_) => {
+                            info!("Ignore unexpected frame");
+                            None
+                        }
+                    };
 
-            let msg = match message {
-                Message::Text(str) => {
-                    let parsed: serde_json::Result<InstanceConnectMessage> =
-                        serde_json::from_str(&str);
-                    Some(parsed.unwrap()) // TODO: error handling
-                }
-                Message::Binary(data) => {
-                    let parsed: serde_json::Result<InstanceConnectMessage> =
-                        serde_json::from_slice(&data);
-                    Some(parsed.unwrap()) // TODO: error handling
-                }
-                Message::Ping(_) => {
-                    debug!("Ignore ping");
-                    None
-                }
-                Message::Pong(_) => {
-                    debug!("Ignore pong");
-                    None
-                }
-                Message::Close(_) => {
-                    info!("Ignore unexpected close");
-                    None
-                }
-                Message::Frame(_) => {
-                    info!("Ignore unexpected frame");
-                    None
-                }
-            };
-
-            match msg {
-                None => {}
-                Some(msg) => match msg.event {
-                    WorkerEvent::Stdout(StdOutLog { message }) => {
-                        print!("{message}")
+                    match msg {
+                        None => {}
+                        Some(msg) => match msg.event {
+                            WorkerEvent::Stdout(StdOutLog { message }) => {
+                                print!("{message}")
+                            }
+                            WorkerEvent::Stderr(StdErrLog { message }) => {
+                                print!("{message}")
+                            }
+                            WorkerEvent::Log(Log {
+                                level,
+                                context,
+                                message,
+                            }) => match level {
+                                0 => tracing::trace!(message, context = context),
+                                1 => tracing::debug!(message, context = context),
+                                2 => tracing::info!(message, context = context),
+                                3 => tracing::warn!(message, context = context),
+                                _ => tracing::error!(message, context = context),
+                            },
+                        },
                     }
-                    WorkerEvent::Stderr(StdErrLog { message }) => {
-                        print!("{message}")
-                    }
-                    WorkerEvent::Log(Log {
-                        level,
-                        context,
-                        message,
-                    }) => match level {
-                        0 => tracing::trace!(message, context = context),
-                        1 => tracing::debug!(message, context = context),
-                        2 => tracing::info!(message, context = context),
-                        3 => tracing::warn!(message, context = context),
-                        _ => tracing::error!(message, context = context),
-                    },
-                },
+                }
             }
         });
 

--- a/src/clients/worker.rs
+++ b/src/clients/worker.rs
@@ -309,7 +309,6 @@ impl<C: golem_client::api::WorkerClient + Sync + Send> WorkerClient for WorkerCl
             match message {
                 Err(e) => {
                     print!("Error reading message: {}", e);
-                    return;
                 }
                 Ok(msgg) => {
                     let msg = match msgg {

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -213,9 +213,12 @@ impl<'r, C: WorkerClient + Send + Sync, R: TemplateHandler + Send + Sync> Worker
             } => {
                 let template_id = self.templates.resolve_id(template_id_or_name).await?;
 
-                self.client.connect(worker_name, template_id).await?;
+                let result = self.client.connect(worker_name, template_id).await;
 
-                Err(GolemError("connect should never complete".to_string()))
+                match result {
+                    Ok(_) => Err(GolemError("Unexpected connection closure".to_string())),
+                    Err(err) => Err(GolemError(err.to_string())),
+                }
             }
             WorkerSubcommand::Interrupt {
                 template_id_or_name,


### PR DESCRIPTION
Tested and these changes are required to propagate error messages from servers.

It also avoid confusing message such as "Error: connect should never complete" especially a connection closure can be intentional from servers. So a more generic message is 

```scala

/golem-cli --golem-url http://localhost:8080/ worker connect --template-id 32cac6c9-4e4a-44c9-8245-359db18f3447 --worker-name myworkerqq
Error: Unexpected connection closure
Connection Closed: Error connecting to worker: Worker not found: 32cac6c9-4e4a-44c9-8245-359db18f3447/myworkerqq (1011)%
```


The above error message requires closing websocket in the event of failure with proper details. That PR is going to come in server side soon.