### PR TITLE
infanticide

### DIFF
--- a/tests/worker.rs
+++ b/tests/worker.rs
@@ -311,6 +311,8 @@ fn worker_connect((context, name, cli): (Arc<ContextInfo>, String, CliLive)) -> 
 
     assert_eq!(line, "Sample text written to the output");
 
+    child.kill()?;
+
     Ok(())
 }
 


### PR DESCRIPTION
Killing children is important - `Drop` does nothing.