### PR TITLE
version command reports build time VERSION env or Cargo.toml version

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -65,7 +65,7 @@ enum Command {
 }
 
 #[derive(Parser, Debug)]
-#[command(author, version, about, long_about, rename_all = "kebab-case")]
+#[command(author, version=option_env!("VERSION").unwrap_or(env!("CARGO_PKG_VERSION")), about, long_about, rename_all = "kebab-case")]
 /// Command line interface for OSS version of Golem.
 ///
 /// For Golem Cloud client see golem-cloud-cli instead: https://github.com/golemcloud/golem-cloud-cli


### PR DESCRIPTION
## What?
* If VERSION env variable was available at built time
  * `golem-cli --version` will return that value
* Otherwise
  * `golem-cli --version` will return the build time version found in Cargo.toml 


## Why?
Because, currently, builds outside of the CI always return 0.0.0 (the Cargo.toml default)
This is helpful for things like creating a nix package. (The current way of changing the Cargo.toml leads to hash differences in a nix context.)
