### PR TITLE
Remove printing out worker name for API definitions

### DIFF
--- a/golem-cli/src/model/text.rs
+++ b/golem-cli/src/model/text.rs
@@ -353,7 +353,7 @@ pub mod api_definition {
         #[table(title = "Path")]
         pub path: String,
         #[table(title = "Component URN", justify = "Justify::Right")]
-        pub component_urn: String
+        pub component_urn: String,
     }
 
     impl From<&RouteResponseData> for RouteTableView {
@@ -372,7 +372,7 @@ pub mod api_definition {
                         .to_string()
                     })
                     .unwrap_or("NA".to_string())
-                    .to_string()
+                    .to_string(),
             }
         }
     }

--- a/golem-cli/src/model/text.rs
+++ b/golem-cli/src/model/text.rs
@@ -353,9 +353,7 @@ pub mod api_definition {
         #[table(title = "Path")]
         pub path: String,
         #[table(title = "Component URN", justify = "Justify::Right")]
-        pub component_urn: String,
-        #[table(title = "Worker Name")]
-        pub worker_name: String,
+        pub component_urn: String
     }
 
     impl From<&RouteResponseData> for RouteTableView {
@@ -374,13 +372,7 @@ pub mod api_definition {
                         .to_string()
                     })
                     .unwrap_or("NA".to_string())
-                    .to_string(),
-
-                worker_name: value
-                    .binding
-                    .worker_name
-                    .clone()
-                    .unwrap_or("<NA/ephemeral>".to_string()),
+                    .to_string()
             }
         }
     }


### PR DESCRIPTION
Fix #119 

API definitions listed worker name separately whcih doesn't make much sense anymore with first class worker support.
We can inspect rib response mapping script and print out the worker names but I don't think its worth it. Users can always read their Rib script to understand the worker name.

Whether we make inspect the worker name and printing  out in future (which requires some work), shouldn't stop us from removing this wrong information being printed out as of now.