### PR TITLE
Fix how WIT parsing errors are reported

### DIFF
--- a/wasm-rpc-stubgen/src/commands/app.rs
+++ b/wasm-rpc-stubgen/src/commands/app.rs
@@ -207,7 +207,7 @@ impl<CPE: ComponentPropertiesExtensions> ApplicationContext<CPE> {
             .as_ref()
         {
             Ok(wit_deps) => Ok(wit_deps),
-            Err(err) => Err(anyhow!("Failed to init wit dependency resolver: {}", err)),
+            Err(err) => Err(anyhow!("Failed to init wit dependency resolver: {:#}", err)),
         }
     }
 


### PR DESCRIPTION
Resolves #96 

Unfortunately I could not find an easy way to write a test for this (as it requires a full app context to call the problematic function)