### PR TITLE
Changes and fixes how common wit directory is handled

### DIFF
--- a/golem-examples/examples/c/c-app-common/golem.yaml
+++ b/golem-examples/examples/c/c-app-common/golem.yaml
@@ -7,4 +7,4 @@ includes:
 - common-*/golem.yaml
 - components-*/*/golem.yaml
 witDeps:
-- common-wit-deps
+- wit/deps

--- a/golem-examples/examples/c/c-app-common/metadata.json
+++ b/golem-examples/examples/c/c-app-common/metadata.json
@@ -6,7 +6,7 @@
   "requiresGolemHostWIT": true,
   "requiresWASI": true,
   "witDepsPaths": [
-    "common-wit-deps"
+    "wit/deps"
   ],
   "transform": false
 }

--- a/golem-examples/examples/c/c-app-common/wit/common.wit
+++ b/golem-examples/examples/c/c-app-common/wit/common.wit
@@ -1,0 +1,1 @@
+package common:root;

--- a/golem-examples/examples/go/go-app-common/golem.yaml
+++ b/golem-examples/examples/go/go-app-common/golem.yaml
@@ -7,4 +7,4 @@ includes:
 - common-*/golem.yaml
 - components-*/*/golem.yaml
 witDeps:
-- common-wit-deps
+- wit/deps

--- a/golem-examples/examples/go/go-app-common/metadata.json
+++ b/golem-examples/examples/go/go-app-common/metadata.json
@@ -6,7 +6,7 @@
   "requiresGolemHostWIT": true,
   "requiresWASI": true,
   "witDepsPaths": [
-    "common-wit-deps"
+    "wit/deps"
   ],
   "transform": false
 }

--- a/golem-examples/examples/go/go-app-common/wit/common.wit
+++ b/golem-examples/examples/go/go-app-common/wit/common.wit
@@ -1,0 +1,1 @@
+package common:root;

--- a/golem-examples/examples/python/python-app-common/golem.yaml
+++ b/golem-examples/examples/python/python-app-common/golem.yaml
@@ -7,4 +7,4 @@ includes:
 - common-*/golem.yaml
 - components-*/*/golem.yaml
 witDeps:
-- common-wit-deps
+- wit/deps

--- a/golem-examples/examples/python/python-app-common/metadata.json
+++ b/golem-examples/examples/python/python-app-common/metadata.json
@@ -5,7 +5,7 @@
   "requiresGolemHostWIT": true,
   "requiresWASI": true,
   "witDepsPaths": [
-    "common-wit-deps"
+    "wit/deps"
   ],
   "transform": false
 }

--- a/golem-examples/examples/python/python-app-common/wit/common.wit
+++ b/golem-examples/examples/python/python-app-common/wit/common.wit
@@ -1,0 +1,1 @@
+package common:root;

--- a/golem-examples/examples/rust/rust-app-common/golem.yaml
+++ b/golem-examples/examples/rust/rust-app-common/golem.yaml
@@ -7,4 +7,4 @@ includes:
 - common-*/golem.yaml
 - components-*/*/golem.yaml
 witDeps:
-- common-wit-deps
+- wit/deps

--- a/golem-examples/examples/rust/rust-app-common/metadata.json
+++ b/golem-examples/examples/rust/rust-app-common/metadata.json
@@ -5,7 +5,7 @@
   "requiresGolemHostWIT": true,
   "requiresWASI": true,
   "witDepsPaths": [
-    "common-wit-deps"
+    "wit/deps"
   ],
   "transform": false
 }

--- a/golem-examples/examples/rust/rust-app-common/wit/common.wit
+++ b/golem-examples/examples/rust/rust-app-common/wit/common.wit
@@ -1,0 +1,1 @@
+package common:root;

--- a/golem-examples/examples/ts/ts-app-common/golem.yaml
+++ b/golem-examples/examples/ts/ts-app-common/golem.yaml
@@ -7,4 +7,4 @@ includes:
 - common-*/golem.yaml
 - components-*/*/golem.yaml
 witDeps:
-- common-wit-deps
+- wit/deps

--- a/golem-examples/examples/ts/ts-app-common/metadata.json
+++ b/golem-examples/examples/ts/ts-app-common/metadata.json
@@ -5,7 +5,7 @@
   "requiresGolemHostWIT": true,
   "requiresWASI": true,
   "witDepsPaths": [
-    "common-wit-deps"
+    "wit/deps"
   ],
   "transform": false
 }

--- a/golem-examples/examples/ts/ts-app-common/wit/common.wit
+++ b/golem-examples/examples/ts/ts-app-common/wit/common.wit
@@ -1,0 +1,1 @@
+package common:root;

--- a/golem-examples/src/lib.rs
+++ b/golem-examples/src/lib.rs
@@ -140,7 +140,6 @@ pub fn instantiate_example(
         };
 
         fs::create_dir_all(&adapter_dir)?;
-        println!("{:?}", &ADAPTERS.entries().iter().collect::<Vec<_>>());
         copy(
             &ADAPTERS,
             adapter_path,

--- a/wasm-rpc-stubgen/src/wit_resolve.rs
+++ b/wasm-rpc-stubgen/src/wit_resolve.rs
@@ -302,9 +302,7 @@ impl ResolvedWitApplication {
                     .collect();
 
                 let source_contained_package_deps = {
-                    let deps_path =
-                        Path::new(&app.component_properties(component_name, profile).source_wit)
-                            .join("deps");
+                    let deps_path = source_wit_dir.join("deps");
                     if !deps_path.exists() {
                         HashSet::new()
                     } else {


### PR DESCRIPTION
- Changes the common wit root to `wit/deps` from `common-wit-deps` in all templates
- And adds a "dummy" `wit/common.wit` to the common templates.

This change alone makes the common wit root "valid" for other tools for example we can now generate bindings from it like this:

```rust
use wit_bindgen::generate;

generate!({
    path: "../../wit",
    generate_all,
    inline: r"
        package golem:test;

        world model-world {
            import wasi:cli/exit@0.2.0;
        }
    ",
    additional_derives: [serde::Deserialize, serde::Serialize],
});
```
from a common rust library.

In addition to that, there was a *bug* that used the root `wit/deps` instead of the one in the component's directory, which just silently broke things when the common wit root was accidentally got that same name. It is fixed now.

Also removed a debug print.

Resolves #101 