### PR TITLE
Print more detailed errors

### DIFF
--- a/golem-cli/src/command_handler/mod.rs
+++ b/golem-cli/src/command_handler/mod.rs
@@ -189,7 +189,7 @@ impl<Hooks: CommandHandlerHooks> CommandHandler<Hooks> {
             if error.downcast_ref::<NonSuccessfulExit>().is_none() {
                 // TODO: check if this should be display or debug
                 logln("");
-                log_error(format!("{}", error));
+                log_error(format!("{:#}", error));
             }
             ExitCode::FAILURE
         })


### PR DESCRIPTION
Before:
```
λ golem api definition update api.yaml

error: Failed to parse API definition as YAML
```

After:

```
λ golem api definition update api.yaml

error: Failed to parse API definition as YAML: routes[4].method: unknown variant `PUIT`, expected one of `Get`, `Connect`, `Post`, `Delete`, `Put`, `Patch`, `Options`, `Trace`, `Head` at line 65 column 13
```