### PR TITLE
Publish and install fixes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -146,6 +146,8 @@ jobs:
     runs-on: ${{ matrix.cfg.os }}
     permissions:
       contents: write
+    env:
+      CARGO_BUILD_JOBS: 10
     steps:
       - uses: actions/checkout@v4
       - name: Checkout

--- a/golem-cli/build.rs
+++ b/golem-cli/build.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use shadow_rs::{BuildPattern, SdResult, ShadowBuilder, ShadowError};
+use shadow_rs::{BuildPattern, SdResult, ShadowBuilder};
 use std::fs::File;
 use std::io::Write;
 use std::process::Command;

--- a/golem-cli/build.rs
+++ b/golem-cli/build.rs
@@ -34,19 +34,24 @@ fn append_write_git_describe_tags(mut file: &File) -> SdResult<()> {
     let output = Command::new("git")
         .args(["describe", "--tags", "--always"])
         .output()?;
-    if !output.status.success() {
-        println!("cargo::error=git describe failed:");
-        for line in String::from_utf8_lossy(&output.stdout).lines() {
-            println!("cargo::error=stdout: {}", line);
-        }
-        for line in String::from_utf8_lossy(&output.stderr).lines() {
-            println!("cargo::error=stderr: {}", line);
-        }
 
-        return Err(ShadowError::from("git describe failed"));
-    }
-    let version = String::from_utf8(output.stdout)?.trim().to_string();
-    println!("cargo::warning=git describe result: {}", version);
+    let version = {
+        if !output.status.success() {
+            println!("cargo::warn=git describe failed, using fallback version 0.0.0");
+            for line in String::from_utf8_lossy(&output.stdout).lines() {
+                println!("cargo::warn=git stdout: {}", line);
+            }
+            for line in String::from_utf8_lossy(&output.stderr).lines() {
+                println!("cargo::warn=git stderr: {}", line);
+            }
+
+            "0.0.0".to_string()
+        } else {
+            let version = String::from_utf8(output.stdout)?.trim().to_string();
+            println!("cargo::warning=git describe result: {}", version);
+            version
+        }
+    };
 
     let git_describe_tags = format!(
         r#"#[allow(clippy::all, clippy::pedantic, clippy::restriction, clippy::nursery)]


### PR DESCRIPTION
NOTE: when using "cargo install", the app will use the PKG_VERSION, given that won't be "0.0.0", so this fallback is only for not failing during build.rs, and this is how previously git_version worked too, see
https://github.com/golemcloud/golem-cli/blob/8be7d29c9d0d91f75326008e0ff79c83d432d772/golem-cli/src/lib.rs#L48-L54