### PR TITLE
Fix snake case conversion for rust templates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,16 +3,6 @@
 version = 4
 
 [[package]]
-name = "Inflector"
-version = "0.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
-dependencies = [
- "lazy_static 1.5.0",
- "regex",
-]
-
-[[package]]
 name = "addr2line"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4026,7 +4016,6 @@ dependencies = [
 name = "golem-templates"
 version = "0.0.0"
 dependencies = [
- "Inflector",
  "anyhow",
  "assert2",
  "cargo_metadata",
@@ -4036,6 +4025,7 @@ dependencies = [
  "fancy-regex",
  "fs_extra",
  "golem-wit",
+ "heck 0.5.0",
  "include_dir",
  "itertools 0.14.0",
  "nanoid",

--- a/golem-templates/Cargo.toml
+++ b/golem-templates/Cargo.toml
@@ -10,7 +10,6 @@ default-run = "golem-templates-test-cli"
 autotests = false
 
 [dependencies]
-Inflector = { workspace = true }
 anyhow = { workspace = true }
 assert2 = { workspace = true }
 clap = { workspace = true }
@@ -18,6 +17,7 @@ colored = { workspace = true }
 fancy-regex = { workspace = true }
 fs_extra = { workspace = true }
 golem-wit = { workspace = true }
+heck = { workspace = true }
 include_dir = { workspace = true }
 itertools = { workspace = true }
 nanoid = { workspace = true }

--- a/golem-templates/src/model.rs
+++ b/golem-templates/src/model.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use fancy_regex::{Match, Regex};
-use inflector::Inflector;
+use heck::{ToLowerCamelCase, ToPascalCase, ToSnakeCase, ToTitleCase};
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::fmt::Formatter;
@@ -73,7 +73,7 @@ impl ComponentName {
     }
 
     pub fn to_camel_case(&self) -> String {
-        self.to_pascal_case().to_camel_case()
+        self.to_pascal_case().to_lower_camel_case()
     }
 }
 
@@ -462,6 +462,7 @@ pub(crate) struct TemplateMetadata {
 #[cfg(test)]
 mod tests {
     use crate::model::{ComponentName, PackageName};
+    use test_r::test;
 
     #[allow(dead_code)]
     fn n1() -> ComponentName {
@@ -529,5 +530,15 @@ mod tests {
     pub fn package_name_to_pascal_case() {
         assert_eq!(p1().to_pascal_case(), "FooBar");
         assert_eq!(p2().to_pascal_case(), "FooBarBaz");
+    }
+
+    #[test]
+    pub fn package_name_with_number() {
+        assert_eq!(
+            PackageName::from_string("example:demo1")
+                .unwrap()
+                .to_rust_binding(),
+            "example::demo1"
+        )
     }
 }


### PR DESCRIPTION
This fixes the template instantiation for package names containing a number (for example `example:cart1`) by using the same library for it as `wit-bindgen`.