### PR TITLE
Fix JS templates

### DIFF
--- a/golem-templates/templates/js/js-app-common/common-js/rollup.config.component.mjs
+++ b/golem-templates/templates/js/js-app-common/common-js/rollup.config.component.mjs
@@ -17,7 +17,7 @@ export default function componentRollupConfig() {
             .readdirSync(generated_interfaces_dir, {withFileTypes: true})
             .filter(dirent => dirent.isFile() && dirent.name.endsWith(".d.ts"))
             .flatMap(dirent =>
-                [...fs.readFileSync(path.join(dirent.parentPath, dirent.name))
+                [...fs.readFileSync(path.join(generated_interfaces_dir, dirent.name))
                     .toString()
                     .matchAll(moduleRegex)]
                     .map((match) => {

--- a/golem-templates/templates/js/js-app-common/common-js/scripts/jco-wrapper.mjs
+++ b/golem-templates/templates/js/js-app-common/common-js/scripts/jco-wrapper.mjs
@@ -42,7 +42,7 @@ function asyncAction (cmd) {
       catch (e) {
         process.stdout.write(`(jco ${cmd.name}) `);
         if (typeof e === 'string') {
-          console.error(c`{red.bold Error}: ${e}\n`);
+          console.error(`{red.bold Error}: ${e}\n`);
         } else {
           console.error(e);
         }

--- a/golem-templates/templates/ts/ts-app-common/common-ts/scripts/jco-wrapper.mjs
+++ b/golem-templates/templates/ts/ts-app-common/common-ts/scripts/jco-wrapper.mjs
@@ -42,7 +42,7 @@ function asyncAction (cmd) {
       catch (e) {
         process.stdout.write(`(jco ${cmd.name}) `);
         if (typeof e === 'string') {
-          console.error(c`{red.bold Error}: ${e}\n`);
+          console.error(`{red.bold Error}: ${e}\n`);
         } else {
           console.error(e);
         }


### PR DESCRIPTION
Fixes typo in eco wrapper.
Replaces experimental `dirent.parentPath` with directory path available in plain variable.