### PR TITLE
Worker stream fixes

### DIFF
--- a/golem-cli/src/command_handler/worker/mod.rs
+++ b/golem-cli/src/command_handler/worker/mod.rs
@@ -12,13 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod stream;
+mod stream_output;
+
 use crate::cloud::AccountId;
 use crate::command::shared_args::{
     NewWorkerArgument, StreamArgs, WorkerFunctionArgument, WorkerFunctionName, WorkerNameArg,
 };
 use crate::command::worker::WorkerSubcommand;
+use crate::command_handler::worker::stream::WorkerConnection;
 use crate::command_handler::Handlers;
-use crate::connect_output::ConnectOutput;
 use crate::context::{Context, GolemClients};
 use crate::error::service::{AnyhowMapServiceError, ServiceError};
 use crate::error::NonSuccessfulExit;
@@ -41,14 +44,11 @@ use crate::model::text::worker::{WorkerCreateView, WorkerGetView};
 use crate::model::to_oss::ToOss;
 use crate::model::worker::fuzzy_match_function_name;
 use crate::model::{
-    ComponentName, ComponentNameMatchKind, Format, IdempotencyKey, ProjectName,
-    WorkerConnectOptions, WorkerMetadata, WorkerMetadataView, WorkerName, WorkerNameMatch,
-    WorkerUpdateMode, WorkersMetadataResponseView,
+    ComponentName, ComponentNameMatchKind, IdempotencyKey, ProjectName, WorkerMetadata,
+    WorkerMetadataView, WorkerName, WorkerNameMatch, WorkerUpdateMode, WorkersMetadataResponseView,
 };
-use anyhow::{anyhow, bail, Context as AnyhowContext};
-use bytes::Bytes;
+use anyhow::{anyhow, bail};
 use colored::Colorize;
-use futures_util::{future, pin_mut, SinkExt, StreamExt};
 use golem_client::api::WorkerClient as WorkerClientOss;
 use golem_client::model::{
     InvokeParameters as InvokeParametersOss, InvokeResult, PublicOplogEntry,
@@ -65,21 +65,11 @@ use golem_cloud_client::model::{
     WorkerCreationRequest as WorkerCreationRequestCloud,
 };
 use golem_common::model::public_oplog::OplogCursor;
-use golem_common::model::WorkerEvent;
 use golem_wasm_rpc::json::OptionallyTypeAnnotatedValueJson;
 use golem_wasm_rpc::parse_type_annotated_value;
 use itertools::{EitherOrBoth, Itertools};
-use native_tls::TlsConnector;
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::Duration;
-use tokio::task::JoinHandle;
-use tokio::{task, time};
-use tokio_tungstenite::tungstenite::client::IntoClientRequest;
-use tokio_tungstenite::tungstenite::Message;
-use tokio_tungstenite::{connect_async_tls_with_config, tungstenite, Connector};
-use tracing::{debug, error, info, trace};
-use url::Url;
 use uuid::Uuid;
 
 pub struct WorkerCommandHandler {
@@ -409,7 +399,7 @@ impl WorkerCommandHandler {
             format!("to worker {}", format_worker_name_match(&worker_name_match)),
         );
 
-        let connection = connect_to_worker(
+        let connection = WorkerConnection::new(
             self.ctx.worker_service_url().clone(),
             self.ctx.auth_token().await?,
             component.versioned_component_id.component_id,
@@ -420,7 +410,7 @@ impl WorkerCommandHandler {
         )
         .await?;
 
-        connection.read_messages().await;
+        connection.run_forever().await;
 
         Ok(())
     }
@@ -933,7 +923,7 @@ impl WorkerCommandHandler {
         let connect_handle = match &worker_name {
             Some(worker_name) => match stream_args {
                 Some(stream_args) => {
-                    let connection = connect_to_worker(
+                    let connection = WorkerConnection::new(
                         self.ctx.worker_service_url().clone(),
                         self.ctx.auth_token().await?,
                         component.versioned_component_id.component_id,
@@ -943,9 +933,9 @@ impl WorkerCommandHandler {
                         self.ctx.format(),
                     )
                     .await?;
-                    Some(tokio::task::spawn(async move {
-                        connection.read_messages().await
-                    }))
+                    Some(tokio::task::spawn(
+                        async move { connection.run_forever().await },
+                    ))
                 }
                 None => None,
             },
@@ -1902,206 +1892,4 @@ fn parse_worker_error(status: u16, body: Vec<u8>) -> ServiceError {
                 .into()
         }
     }
-}
-
-struct WorkerConnection {
-    pings: JoinHandle<anyhow::Error>,
-    read_messages: JoinHandle<()>,
-}
-
-impl WorkerConnection {
-    async fn read_messages(self) {
-        let pings = self.pings;
-        let read_res = self.read_messages;
-        pin_mut!(pings, read_res);
-        future::select(pings, read_res).await;
-    }
-}
-
-async fn connect_to_worker(
-    worker_service_url: Url,
-    auth_token: Option<String>,
-    component_id: Uuid,
-    worker_name: String,
-    connect_options: WorkerConnectOptions,
-    allow_insecure: bool,
-    format: Format,
-) -> anyhow::Result<WorkerConnection> {
-    let mut url = worker_service_url;
-
-    let ws_schema = if url.scheme() == "http" { "ws" } else { "wss" };
-
-    url.set_scheme(ws_schema)
-        .map_err(|()| anyhow!("Failed to set ws url schema".to_string()))?;
-    url.path_segments_mut()
-        .map_err(|()| anyhow!("Failed to get url path for ws url".to_string()))?
-        .push("v1")
-        .push("components")
-        .push(&component_id.to_string())
-        .push("workers")
-        .push(&worker_name)
-        .push("connect");
-
-    debug!(url = url.as_str(), "Worker connect");
-
-    let mut request = url
-        .to_string()
-        .into_client_request()
-        .context("Failed to create request")?;
-
-    if let Some(token) = auth_token {
-        let headers = request.headers_mut();
-        headers.insert("Authorization", format!("Bearer {}", token).parse()?);
-    }
-
-    let connector = if allow_insecure {
-        Some(Connector::NativeTls(
-            TlsConnector::builder()
-                .danger_accept_invalid_certs(true)
-                .danger_accept_invalid_hostnames(true)
-                .build()?,
-        ))
-    } else {
-        None
-    };
-
-    let (ws_stream, _) = connect_async_tls_with_config(request, None, false, connector)
-        .await
-        .map_err(|e| match e {
-            tungstenite::error::Error::Http(http_error_response) => {
-                let status = http_error_response.status().as_u16();
-                match http_error_response.body().clone() {
-                    Some(body) => anyhow!(parse_worker_error(status, body)),
-                    None => anyhow!("Websocket connect failed, HTTP error: {}", status),
-                }
-            }
-            _ => anyhow!("Websocket connect failed, error: {}", e),
-        })?;
-
-    let (mut write, read) = ws_stream.split();
-
-    let pings = task::spawn(async move {
-        let mut interval = time::interval(Duration::from_secs(1)); // TODO configure
-        let mut cnt: i64 = 1;
-
-        loop {
-            interval.tick().await;
-
-            let ping_result = write
-                .send(Message::Ping(Bytes::from(cnt.to_ne_bytes().to_vec())))
-                .await
-                .context("Failed to send ping");
-
-            if let Err(err) = ping_result {
-                error!("{}", err);
-                break err;
-            }
-
-            cnt += 1;
-        }
-    });
-
-    let output = ConnectOutput::new(connect_options, format);
-
-    let read_messages = task::spawn(async move {
-        read.for_each(move |message_or_error| {
-            let output = output.clone();
-            async move {
-                match message_or_error {
-                    Err(error) => {
-                        error!("Error reading message: {}", error);
-                    }
-                    Ok(message) => {
-                        let instance_connect_msg = match message {
-                            Message::Text(str) => {
-                                let parsed: serde_json::Result<WorkerEvent> =
-                                    serde_json::from_str(str.as_str());
-
-                                match parsed {
-                                    Ok(parsed) => Some(parsed),
-                                    Err(err) => {
-                                        error!("Failed to parse worker connect message: {err}");
-                                        None
-                                    }
-                                }
-                            }
-                            Message::Binary(data) => {
-                                let parsed: serde_json::Result<WorkerEvent> =
-                                    serde_json::from_slice(data.as_ref());
-                                match parsed {
-                                    Ok(parsed) => Some(parsed),
-                                    Err(err) => {
-                                        error!("Failed to parse worker connect message: {err}");
-                                        None
-                                    }
-                                }
-                            }
-                            Message::Ping(_) => {
-                                trace!("Ignore ping");
-                                None
-                            }
-                            Message::Pong(_) => {
-                                trace!("Ignore pong");
-                                None
-                            }
-                            Message::Close(details) => {
-                                match details {
-                                    Some(closed_frame) => {
-                                        info!("Connection Closed: {}", closed_frame);
-                                    }
-                                    None => {
-                                        info!("Connection Closed");
-                                    }
-                                }
-                                None
-                            }
-                            Message::Frame(f) => {
-                                debug!("Ignored unexpected frame {f:?}");
-                                None
-                            }
-                        };
-
-                        match instance_connect_msg {
-                            None => {}
-                            Some(msg) => match msg {
-                                WorkerEvent::StdOut { timestamp, bytes } => {
-                                    output
-                                        .emit_stdout(
-                                            timestamp,
-                                            String::from_utf8_lossy(&bytes).to_string(),
-                                        )
-                                        .await;
-                                }
-                                WorkerEvent::StdErr { timestamp, bytes } => {
-                                    output
-                                        .emit_stderr(
-                                            timestamp,
-                                            String::from_utf8_lossy(&bytes).to_string(),
-                                        )
-                                        .await;
-                                }
-                                WorkerEvent::Log {
-                                    timestamp,
-                                    level,
-                                    context,
-                                    message,
-                                } => {
-                                    output.emit_log(timestamp, level, context, message);
-                                }
-                                WorkerEvent::Close => {} // TODO:
-                                WorkerEvent::InvocationStart { .. } => {} // TODO:
-                                WorkerEvent::InvocationFinished { .. } => {} // TODO:
-                            },
-                        }
-                    }
-                }
-            }
-        })
-        .await;
-    });
-
-    Ok(WorkerConnection {
-        pings,
-        read_messages,
-    })
 }

--- a/golem-cli/src/command_handler/worker/stream.rs
+++ b/golem-cli/src/command_handler/worker/stream.rs
@@ -1,0 +1,311 @@
+// Copyright 2024-2025 Golem Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::command_handler::worker::parse_worker_error;
+use crate::command_handler::worker::stream_output::WorkerStreamOutput;
+use crate::model::{Format, WorkerConnectOptions};
+use anyhow::{anyhow, Context};
+use bytes::Bytes;
+use futures_util::future::Either;
+use futures_util::stream::{SplitSink, SplitStream};
+use futures_util::{future, pin_mut, SinkExt, StreamExt};
+use golem_common::model::{Timestamp, WorkerEvent};
+use native_tls::TlsConnector;
+use std::time::Duration;
+use tokio::net::TcpStream;
+use tokio::{task, time};
+use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+use tokio_tungstenite::tungstenite::handshake::client::Request;
+use tokio_tungstenite::tungstenite::Message;
+use tokio_tungstenite::{
+    connect_async_tls_with_config, tungstenite, Connector, MaybeTlsStream, WebSocketStream,
+};
+use tracing::{debug, error, info, trace};
+use url::Url;
+use uuid::Uuid;
+
+pub struct WorkerConnection {
+    request: Request,
+    connector: Option<Connector>,
+    output: WorkerStreamOutput,
+}
+
+impl WorkerConnection {
+    /// Initializes a worker stream. Use `run_forever` to connect and output worker events.
+    pub async fn new(
+        worker_service_url: Url,
+        auth_token: Option<String>,
+        component_id: Uuid,
+        worker_name: String,
+        connect_options: WorkerConnectOptions,
+        allow_insecure: bool,
+        format: Format,
+    ) -> anyhow::Result<WorkerConnection> {
+        let (request, connector) = Self::create_request(
+            worker_service_url,
+            auth_token,
+            component_id,
+            worker_name,
+            allow_insecure,
+        )?;
+        let output = WorkerStreamOutput::new(connect_options, format);
+
+        Ok(Self {
+            request,
+            connector,
+            output,
+        })
+    }
+
+    /// Creates a new worker connection and every time the connection is dropped tries to
+    /// reconnect
+    pub async fn run_forever(self) {
+        loop {
+            let _ = self.run().await;
+            self.output.flush().await;
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    }
+
+    /// Connects to the worker event stream and outputs incoming messages until the connection is dropped
+    async fn run(&self) -> anyhow::Result<()> {
+        let (ws_stream, _) = connect_async_tls_with_config(
+            self.request.clone(),
+            None,
+            false,
+            self.connector.clone(),
+        )
+        .await
+        .map_err(|e| match e {
+            tungstenite::error::Error::Http(http_error_response) => {
+                let status = http_error_response.status().as_u16();
+                match http_error_response.body().clone() {
+                    Some(body) => anyhow!(parse_worker_error(status, body)),
+                    None => anyhow!("Websocket connect failed, HTTP error: {}", status),
+                }
+            }
+            _ => anyhow!("Websocket connect failed, error: {}", e),
+        })?;
+
+        let (write, read) = ws_stream.split();
+
+        let pings = task::spawn(async move { Self::ping_loop(write).await });
+
+        let output = self.output.clone();
+        let read_messages = task::spawn(async move {
+            Self::read_loop(read, output).await;
+        });
+
+        pin_mut!(pings, read_messages);
+        match future::select(pings, read_messages).await {
+            Either::Left((Ok(result), _)) => Err(result),
+            Either::Left((Err(err), _)) => Err(anyhow!(err)),
+            Either::Right((Ok(_), _)) => Ok(()),
+            Either::Right((Err(err), _)) => Err(anyhow!(err)),
+        }
+    }
+
+    fn create_request(
+        worker_service_url: Url,
+        auth_token: Option<String>,
+        component_id: Uuid,
+        worker_name: String,
+        allow_insecure: bool,
+    ) -> anyhow::Result<(Request, Option<Connector>)> {
+        let mut url = worker_service_url;
+
+        let ws_schema = if url.scheme() == "http" { "ws" } else { "wss" };
+
+        url.set_scheme(ws_schema)
+            .map_err(|()| anyhow!("Failed to set ws url schema".to_string()))?;
+        url.path_segments_mut()
+            .map_err(|()| anyhow!("Failed to get url path for ws url".to_string()))?
+            .push("v1")
+            .push("components")
+            .push(&component_id.to_string())
+            .push("workers")
+            .push(&worker_name)
+            .push("connect");
+
+        debug!(url = url.as_str(), "Worker connect");
+
+        let mut request = url
+            .to_string()
+            .into_client_request()
+            .context("Failed to create request")?;
+
+        if let Some(token) = auth_token {
+            let headers = request.headers_mut();
+            headers.insert("Authorization", format!("Bearer {}", token).parse()?);
+        }
+
+        let connector = if allow_insecure {
+            Some(Connector::NativeTls(
+                TlsConnector::builder()
+                    .danger_accept_invalid_certs(true)
+                    .danger_accept_invalid_hostnames(true)
+                    .build()?,
+            ))
+        } else {
+            None
+        };
+
+        Ok((request, connector))
+    }
+
+    async fn ping_loop(
+        mut write: SplitSink<WebSocketStream<MaybeTlsStream<TcpStream>>, Message>,
+    ) -> anyhow::Error {
+        let mut interval = time::interval(Duration::from_secs(1)); // TODO configure
+        let mut cnt: i64 = 1;
+
+        loop {
+            interval.tick().await;
+
+            let ping_result = write
+                .send(Message::Ping(Bytes::from(cnt.to_ne_bytes().to_vec())))
+                .await
+                .context("Failed to send ping");
+
+            if let Err(err) = ping_result {
+                break err;
+            }
+
+            cnt += 1;
+        }
+    }
+
+    async fn read_loop(
+        read: SplitStream<WebSocketStream<MaybeTlsStream<TcpStream>>>,
+        output: WorkerStreamOutput,
+    ) {
+        read.for_each(move |message_or_error| {
+            let output = output.clone();
+            async move {
+                match message_or_error {
+                    Err(error) => {
+                        error!("Failed to read next message: {}", error);
+                    }
+                    Ok(message) => {
+                        let worker_event = Self::parse_websocket_message(message);
+                        match worker_event {
+                            None => {}
+                            Some(msg) => match msg {
+                                WorkerEvent::StdOut { timestamp, bytes } => {
+                                    output
+                                        .emit_stdout(
+                                            timestamp,
+                                            String::from_utf8_lossy(&bytes).to_string(),
+                                        )
+                                        .await;
+                                }
+                                WorkerEvent::StdErr { timestamp, bytes } => {
+                                    output
+                                        .emit_stderr(
+                                            timestamp,
+                                            String::from_utf8_lossy(&bytes).to_string(),
+                                        )
+                                        .await;
+                                }
+                                WorkerEvent::Log {
+                                    timestamp,
+                                    level,
+                                    context,
+                                    message,
+                                } => {
+                                    output.emit_log(timestamp, level, context, message);
+                                }
+                                WorkerEvent::Close => {
+                                    output.emit_stream_closed(Timestamp::now_utc());
+                                }
+                                WorkerEvent::InvocationStart {
+                                    timestamp,
+                                    function,
+                                    idempotency_key,
+                                } => {
+                                    output.emit_invocation_start(
+                                        timestamp,
+                                        function,
+                                        idempotency_key,
+                                    );
+                                }
+                                WorkerEvent::InvocationFinished {
+                                    timestamp,
+                                    function,
+                                    idempotency_key,
+                                } => {
+                                    output.emit_invocation_finished(
+                                        timestamp,
+                                        function,
+                                        idempotency_key,
+                                    );
+                                }
+                            },
+                        }
+                    }
+                }
+            }
+        })
+        .await;
+    }
+
+    fn parse_websocket_message(message: Message) -> Option<WorkerEvent> {
+        match message {
+            Message::Text(str) => {
+                let parsed: serde_json::Result<WorkerEvent> = serde_json::from_str(str.as_str());
+
+                match parsed {
+                    Ok(parsed) => Some(parsed),
+                    Err(err) => {
+                        error!("Failed to parse worker connect message: {err}");
+                        None
+                    }
+                }
+            }
+            Message::Binary(data) => {
+                let parsed: serde_json::Result<WorkerEvent> = serde_json::from_slice(data.as_ref());
+                match parsed {
+                    Ok(parsed) => Some(parsed),
+                    Err(err) => {
+                        error!("Failed to parse worker connect message: {err}");
+                        None
+                    }
+                }
+            }
+            Message::Ping(_) => {
+                trace!("Ignore ping");
+                None
+            }
+            Message::Pong(_) => {
+                trace!("Ignore pong");
+                None
+            }
+            Message::Close(details) => {
+                match details {
+                    Some(closed_frame) => {
+                        info!("Connection Closed: {}", closed_frame);
+                    }
+                    None => {
+                        info!("Connection Closed");
+                    }
+                }
+                Some(WorkerEvent::Close)
+            }
+            Message::Frame(f) => {
+                debug!("Ignored unexpected frame {f:?}");
+                None
+            }
+        }
+    }
+}

--- a/golem-cli/src/lib.rs
+++ b/golem-cli/src/lib.rs
@@ -22,7 +22,6 @@ pub mod cloud;
 pub mod command;
 pub mod command_handler;
 pub mod config;
-pub mod connect_output;
 pub mod context;
 pub mod diagnose;
 pub mod error;


### PR DESCRIPTION
Resolves #202 
Resolves #200 
Resolves #185 

Fixes and improvers worker log streaming in multiple ways:

- Restored the "infinite transparent reconnect" behavior that we had in the past - so if a worker is moved to another executor or the executor gets restarted the stream restores
- It is now printing invocation boundaries (with function name and idempotency key)
- When using the `invoke --stream` mode, it only shows log messages belonging to the awaited invocation, and tries to wait for all of those messages to arrive
- When using the `invoke --enqueue --stream` mode, it switches to "infinite" streaming (same as `worker stream`), like before the CLI refactor
- It makes sure to not show duplicated messages in case of reconnecting to another worker node (I think this was also protected on server side but added some extra client side logic to make sure it works as expected)