### PR TITLE
Pretty log output for server run

### DIFF
--- a/golem-cli/src/command_handler/mod.rs
+++ b/golem-cli/src/command_handler/mod.rs
@@ -85,6 +85,9 @@ pub trait CommandHandlerHooks {
 
     #[cfg(feature = "server-commands")]
     fn override_verbosity(verbosity: Verbosity) -> Verbosity;
+
+    #[cfg(feature = "server-commands")]
+    fn override_pretty_mode() -> bool;
 }
 
 // CommandHandler is responsible for matching commands and producing CLI output using Context,

--- a/golem-cli/src/command_handler/mod.rs
+++ b/golem-cli/src/command_handler/mod.rs
@@ -153,7 +153,7 @@ impl<Hooks: CommandHandlerHooks> CommandHandler<Hooks> {
                 };
                 #[cfg(not(feature = "server-commands"))]
                 let verbosity = command.global_flags.verbosity();
-                init_tracing(verbosity);
+                init_tracing(verbosity, false);
 
                 match Self::new_with_init_hint_error_handler(&command.global_flags, hooks) {
                     Ok(mut handler) => {
@@ -191,6 +191,7 @@ impl<Hooks: CommandHandlerHooks> CommandHandler<Hooks> {
                         .global_flags
                         .verbosity
                         .as_clap_verbosity_flag(),
+                    false,
                 );
 
                 debug!(partial_match = ?partial_match, "Partial match");
@@ -216,7 +217,7 @@ impl<Hooks: CommandHandlerHooks> CommandHandler<Hooks> {
                 error,
                 fallback_command,
             } => {
-                init_tracing(fallback_command.global_flags.verbosity());
+                init_tracing(fallback_command.global_flags.verbosity(), false);
                 debug_log_parse_error(&error, &fallback_command);
                 error.print().unwrap();
 

--- a/golem-cli/src/lib.rs
+++ b/golem-cli/src/lib.rs
@@ -55,15 +55,27 @@ pub fn version() -> &'static str {
     }
 }
 
-pub fn init_tracing(verbosity: Verbosity) {
+pub fn init_tracing(verbosity: Verbosity, pretty_mode: bool) {
     if let Some(level) = verbosity.tracing_level() {
-        let subscriber = FmtSubscriber::builder()
-            .with_max_level(level)
-            .with_writer(std::io::stderr)
-            .finish();
+        let subscriber = FmtSubscriber::builder();
+        if pretty_mode {
+            let subscriber = subscriber
+                .pretty()
+                .with_max_level(level)
+                .with_writer(std::io::stderr)
+                .finish();
 
-        tracing::subscriber::set_global_default(subscriber)
-            .expect("setting default subscriber failed");
+            tracing::subscriber::set_global_default(subscriber)
+                .expect("setting default subscriber failed");
+        } else {
+            let subscriber = subscriber
+                .with_max_level(level)
+                .with_writer(std::io::stderr)
+                .finish();
+
+            tracing::subscriber::set_global_default(subscriber)
+                .expect("setting default subscriber failed");
+        };
     }
 }
 

--- a/golem-cli/src/main.rs
+++ b/golem-cli/src/main.rs
@@ -42,6 +42,11 @@ mod hooks {
         fn override_verbosity(verbosity: Verbosity) -> Verbosity {
             verbosity
         }
+
+        #[cfg(feature = "server-commands")]
+        fn override_pretty_mode() -> bool {
+            false
+        }
     }
 }
 

--- a/golem-cli/src/model/text/worker.rs
+++ b/golem-cli/src/model/text/worker.rs
@@ -776,6 +776,17 @@ impl TextView for PublicOplogEntry {
                     }
                 ));
             }
+            PublicOplogEntry::ChangePersistenceLevel(params) => {
+                logln(format_message_highlight("CHANGE PERSISTENCE LEVEL"));
+                logln(format!(
+                    "{pad}at:                {}",
+                    format_id(&params.timestamp)
+                ));
+                logln(format!(
+                    "{pad}level:             {}",
+                    format_id(&format!("{:?}", &params.persistence_level))
+                ));
+            }
         }
     }
 }

--- a/golem/src/command_handler.rs
+++ b/golem/src/command_handler.rs
@@ -66,6 +66,10 @@ impl CommandHandlerHooks for ServerCommandHandler {
             Verbosity::new(2, 0)
         }
     }
+
+    fn override_pretty_mode() -> bool {
+        true
+    }
 }
 
 fn default_data_dir() -> anyhow::Result<PathBuf> {


### PR DESCRIPTION
This makes it readable for me :)

Example:

before:

```
2025-04-18T13:07:36.477123Z  INFO retry{target="worker_executor" op="assign_shards" op_id="vigoomac.local:64795 (127.0.0.1)" attempt=1}: golem_common::retries: op success duration_ms=72 target_label="worker_executor" op_label="assign_shards" op_id="vigoomac.local:64795 (127.0.0.1)"
```

after:

```
  2025-04-18T13:08:36.535730Z  INFO golem_common::retries: op success, duration_ms: 73, target_label: "worker_executor", op_label: "assign_shards", op_id: "vigoomac.local:64870 (127.0.0.1)"
    at /Users/vigoo/projects/ziverge/golem-services/golem-common/src/retries.rs:159
    in golem_common::retries::retry with target: "worker_executor", op: "assign_shards", op_id: "vigoomac.local:64870 (127.0.0.1)", attempt: 1
```
