### PR TITLE
Switch python templates to uv and wire up wasi http urllib

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,8 +45,8 @@ jobs:
         uses: arduino/setup-protoc@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Install componentize-py
-        run: pip install componentize-py==0.16.0
+      - name: Install uv
+        run: pip install uv==0.6.17
       - name: Install WASI SDK
         run: |
           WASI_VERSION=25

--- a/golem-templates/templates/python/python-app-common/common-python/golem.yaml
+++ b/golem-templates/templates/python/python-app-common/common-python/golem.yaml
@@ -8,14 +8,14 @@
 templates:
   python:
     build:
-    - command: componentize-py --import-interface-name "wasi:http/types@0.2.0"="types" --import-interface-name "wasi:http/outgoing-handler@0.2.0"="outgoing_handler" --wit-path wit-generated bindings src
+    - command: uv run --package {{ component_name | to_kebab_case }} componentize-py --import-interface-name "wasi:http/types@0.2.0"="types" --import-interface-name "wasi:http/outgoing-handler@0.2.0"="outgoing_handler" --wit-path wit-generated bindings src
       rmdirs:
       - src/{{ component_name | to_snake_case }}
       sources:
       - wit-generated
       targets:
       - src/{{ component_name | to_snake_case }}
-    - command: componentize-py --import-interface-name "wasi:http/types@0.2.0"="types" --import-interface-name "wasi:http/outgoing-handler@0.2.0"="outgoing_handler" --wit-path wit-generated componentize -p src -p ../../common-python component -o ../../golem-temp/python/components/{{ component_name | to_snake_case }}.wasm
+    - command: uv run --package {{ component_name | to_kebab_case }} componentize-py --import-interface-name "wasi:http/types@0.2.0"="types" --import-interface-name "wasi:http/outgoing-handler@0.2.0"="outgoing_handler" --wit-path wit-generated componentize -p src component -o ../../golem-temp/python/components/{{ component_name | to_snake_case }}.wasm
       mkdirs:
       - ../../golem-temp/python/components
       sources:

--- a/golem-templates/templates/python/python-app-common/common-python/pyproject.toml
+++ b/golem-templates/templates/python/python-app-common/common-python/pyproject.toml
@@ -1,0 +1,25 @@
+[project]
+name = "lib"
+version = "0.1.0"
+description = "Add your description here"
+requires-python = ">=3.9"
+dependencies = []
+
+[dependency-groups]
+dev = [
+    "componentize-py==0.16.0",
+]
+
+[build-system]
+requires = ["uv_build"]
+build-backend = "uv_build"
+
+[tool.uv]
+override-dependencies = [
+  # Golem fork of urllib3 that enables usage with WASI
+  "urllib3 @ git+https://github.com/golemcloud/urllib3@1273c71ff7fccfdb5d1415118fa43e786b9d1818"
+]
+
+[tool.uv.build-backend]
+module-root = ""
+module-name = "lib"

--- a/golem-templates/templates/python/python-app-component-default/components-python/component-name/pyproject.toml
+++ b/golem-templates/templates/python/python-app-component-default/components-python/component-name/pyproject.toml
@@ -1,0 +1,23 @@
+[project]
+name = "component-name"
+version = "0.1.0"
+description = "Add your description here"
+requires-python = ">=3.9"
+dependencies = []
+
+[dependency-groups]
+dev = [
+    "componentize-py==0.16.0",
+    "urllib3",
+    "lib"
+]
+
+[tool.uv]
+package = false
+override-dependencies = [
+  # Golem fork of urllib3 that enables usage with WASI
+  "urllib3 @ git+https://github.com/golemcloud/urllib3@1273c71ff7fccfdb5d1415118fa43e786b9d1818"
+]
+
+[tool.uv.sources]
+lib = { path = "../../common-python" }

--- a/golem-templates/templates/python/python-app-component-default/components-python/component-name/src/component.py
+++ b/golem-templates/templates/python/python-app-component-default/components-python/component-name/src/component.py
@@ -1,8 +1,12 @@
-state: int = 0
+# make sure this stays before other urllib uses
+from urllib3.contrib.wasi import enable_wasi_backend
+enable_wasi_backend("component_name")
 
 from pack_name import exports
 # Example common lib import
-# from lib import example_common_function
+from lib import example_common_function
+
+state: int = 0
 
 class ComponentNameApi(exports.ComponentNameApi):
     def add(self, value: int):

--- a/golem-templates/templates/python/python-app-component-default/components-python/component-name/wit/component-name.wit
+++ b/golem-templates/templates/python/python-app-component-default/components-python/component-name/wit/component-name.wit
@@ -8,6 +8,10 @@ interface component-name-api {
 }
 
 world component-name {
+  // Always required due to a limitation of the bindings generation in componentize-py.
+  // This import will fail if removed https://github.com/bytecodealliance/componentize-py/blob/c50822c825b4333ff41a0ea3cd9e0c9bc3df49da/bundled/poll_loop.py#L15
+  import wasi:http/outgoing-handler@0.2.0;
+
   import wasi:cli/environment@0.2.0;
 
   export component-name-api;

--- a/golem-templates/templates/python/python-app-component-wasi-http/components-python/component-name/pyproject.toml
+++ b/golem-templates/templates/python/python-app-component-wasi-http/components-python/component-name/pyproject.toml
@@ -1,0 +1,23 @@
+[project]
+name = "component-name"
+version = "0.1.0"
+description = "Add your description here"
+requires-python = ">=3.9"
+dependencies = []
+
+[dependency-groups]
+dev = [
+    "componentize-py==0.16.0",
+    "urllib3",
+    "lib"
+]
+
+[tool.uv]
+package = false
+override-dependencies = [
+  # Golem fork of urllib3 that enables usage with WASI
+  "urllib3 @ git+https://github.com/golemcloud/urllib3@1273c71ff7fccfdb5d1415118fa43e786b9d1818"
+]
+
+[tool.uv.sources]
+lib = { path = "../../common-python" }

--- a/golem-templates/templates/python/python-app-component-wasi-http/components-python/component-name/src/component.py
+++ b/golem-templates/templates/python/python-app-component-wasi-http/components-python/component-name/src/component.py
@@ -1,26 +1,20 @@
+# make sure this stays before other urllib uses
+from urllib3.contrib.wasi import enable_wasi_backend
+enable_wasi_backend("component_name")
+
 import asyncio
-import poll_loop
 
 from pack_name import exports
 from pack_name.types import Ok
-from pack_name.imports import types
 from pack_name.imports.types import (
     Method_Get,
-    Method_Post,
-    Scheme,
-    Scheme_Http,
-    Scheme_Https,
-    Scheme_Other,
     IncomingRequest,
     ResponseOutparam,
     OutgoingResponse,
     Fields,
     OutgoingBody,
-    OutgoingRequest,
 )
-from poll_loop import Stream, Sink, PollLoop
-from typing import Tuple
-from urllib import parse
+from poll_loop import Sink, PollLoop
 
 # see https://github.com/bytecodealliance/componentize-py/tree/main/examples/http for a full example.
 


### PR DESCRIPTION
resolves https://github.com/golemcloud/golem/issues/1467

[uv](https://docs.astral.sh/uv/) is becoming a quite popular tool in the python ecosystem, so I think there is no big problem with using it as our default.

The main reason I want to do that is that it provides a principled way of overriding transitive dependencies, which I want to use to setup the forked urllib for all users.