### PR TITLE
BindingType for API Definition

### DIFF
--- a/golem-cli/src/model/text/api_definition.rs
+++ b/golem-cli/src/model/text/api_definition.rs
@@ -27,6 +27,8 @@ struct RouteTableView {
     pub path: String,
     #[table(title = "Component Name")]
     pub component_name: ComponentName,
+    #[table(title = "Binding Type")]
+    pub binding_type: String,
 }
 
 impl From<&RouteResponseData> for RouteTableView {
@@ -41,6 +43,10 @@ impl From<&RouteResponseData> for RouteTableView {
                 .map(|component| component.name)
                 .unwrap_or("<NA>".to_string())
                 .into(),
+            binding_type: match &value.binding.binding_type {
+                Some(binding_type) => binding_type.to_string(),
+                None => "<NA>".to_string(),
+            },
         }
     }
 }


### PR DESCRIPTION
closes #222 

Fairly Simple PR, It works in Create, Update and Get API definition

```rust
            binding_type: match &value.binding.binding_type {
                Some(binding_type) => binding_type.to_string(),
                None => "<NA>".to_string(),
            },
```
Could not find any tests for CLI commands           

```bash
Got metadata for API definition todo-list version 0.0.1

ID:         todo-list
Version:    0.0.1
Created at: 2025-04-29 05:14:51.376992617 UTC
Draft:      true
Routes:
  +---------+----------------------------------+----------------+----------------+
  | Method  | Path                             | Component Name | Binding Type   |
  +---------+----------------------------------+----------------+----------------+
  | Options | /v0.0.1/{user}/add               | <NA>           | cors-preflight |
  +---------+----------------------------------+----------------+----------------+
  | Post    | /v0.0.1/{user}/count             | todo-list      | default        |
  +---------+----------------------------------+----------------+----------------+
  | Options | /v0.0.1/{user}/count             | <NA>           | cors-preflight |
  +---------+----------------------------------+----------------+----------------+
  | Post    | /v0.0.1/{user}/delete            | todo-list      | default        |
  +---------+----------------------------------+----------------+----------------+
  | Options | /v0.0.1/{user}/delete            | <NA>           | cors-preflight |
  +---------+----------------------------------+----------------+----------------+
  ```