### PR TITLE
Undeploy CLI commands 

### DIFF
--- a/golem-cli/src/command.rs
+++ b/golem-cli/src/command.rs
@@ -1188,6 +1188,20 @@ pub mod api {
                 #[arg(value_name = "subdomain.host")]
                 site: String,
             },
+            /// Undeploy a specific API definition from a site
+            Undeploy {
+                #[command(flatten)]
+                project: ProjectNameOptionalArg,
+                /// API definition id
+                #[arg(long)]
+                id: String,
+                /// API definition version
+                #[arg(long)]
+                version: String,
+                /// API definition host
+                #[arg(long)]
+                host: String,
+            },
         }
     }
 


### PR DESCRIPTION
Coming full circle, I have added undeploy cli commands, which work for both golem cloud and golem oss. Completing the PR in golem and then once updated completing PR in cli is good way. But I would still prefer a easier way to deal with #156 