### PR TITLE
Schema fixes: external command, env description

### DIFF
--- a/golem-templates/src/lib.rs
+++ b/golem-templates/src/lib.rs
@@ -38,9 +38,9 @@ static RDBMS_WIT: Dir<'_> = include_dir!("$OUT_DIR/golem-rdbms/wit");
 
 static APP_MANIFEST_HEADER: &str = indoc! {"
 # Schema for IDEA:
-# $schema: https://schema.golem.cloud/app/golem/1.2.2/golem.schema.json
+# $schema: https://schema.golem.cloud/app/golem/1.2.2.1/golem.schema.json
 # Schema for vscode-yaml
-# yaml-language-server: $schema=https://schema.golem.cloud/app/golem/1.2.2/golem.schema.json
+# yaml-language-server: $schema=https://schema.golem.cloud/app/golem/1.2.2.1/golem.schema.json
 
 # See https://learn.golem.cloud/docs/app-manifest#field-reference for field reference
 # For creating APIs see https://learn.golem.cloud/invoke/making-custom-apis

--- a/schema.golem.cloud/app/golem/1.2.2.1/golem.schema.json
+++ b/schema.golem.cloud/app/golem/1.2.2.1/golem.schema.json
@@ -1,0 +1,357 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "$id": "https://schema.golem.cloud/app/golem/1.2.2.1/golem.schema.json",
+  "title": "Golem Application Manifest",
+  "description": "Golem Application Manifest.",
+  "type": "object",
+  "properties": {
+    "includes": {
+      "type": "array",
+      "description": "Include paths or globs for searching for application manifest documents. Only allowed in root application manifest documents.",
+      "items": {
+        "type": "string"
+      }
+    },
+    "tempDir": {
+      "type": "string",
+      "description": "Temporary directory used for generating and building WIT and WASM artifacts. Default location is golem-temp."
+    },
+    "witDeps": {
+      "type": "array",
+      "description": "List of source directories for common wit dependency packages",
+      "items": {
+        "type": "string"
+      }
+    },
+    "templates": {
+      "type": "object",
+      "description": "Component definition templates",
+      "additionalProperties": {
+        "$ref": "#/definitions/componentTemplate"
+      }
+    },
+    "components": {
+      "type": "object",
+      "description": "Components by component names",
+      "additionalProperties": {
+        "$ref": "#/definitions/component"
+      }
+    },
+    "dependencies": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/componentDependency"
+        }
+      }
+    },
+    "clean": {
+      "type": "array",
+      "description": "User defined extra paths used in the clean command.",
+      "items": {
+        "type": "string"
+      }
+    },
+    "customCommands": {
+      "type": "object",
+      "description": "User defined custom commands.",
+      "additionalProperties": {
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/externalCommand"
+        }
+      }
+    }
+  },
+  "definitions": {
+    "componentTemplate": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/componentProperties"
+        },
+        {
+          "$ref": "#/definitions/componentProfiles"
+        }
+      ]
+    },
+    "component": {
+      "description": "Component definition",
+      "allOf": [
+        {
+          "type": "object",
+          "properties": {
+            "template": {
+              "type": "string",
+              "description": "Component template to be used for defining this component."
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/componentProperties"
+        },
+        {
+          "$ref": "#/definitions/componentProfiles"
+        }
+      ]
+    },
+    "componentProperties": {
+      "type": "object",
+      "properties": {
+        "sourceWit": {
+          "type": "string",
+          "description": "Source WIT directory for the user defined component WIT source(s)."
+        },
+        "generatedWit": {
+          "type": "string",
+          "description": "Generated WIT directory created by the golem tooling, which handles exported interface extraction and includes resolved package and stub dependencies."
+        },
+        "componentWasm": {
+          "type": "string",
+          "description": "File path for the built WASM component."
+        },
+        "linkedWasm": {
+          "type": "string",
+          "description": "File path for the linked WASM component which is ready to be uploaded to Golem."
+        },
+        "build": {
+          "type": "array",
+          "description": "Commands used for creating component WASM.",
+          "items": {
+            "$ref": "#/definitions/externalCommand"
+          }
+        },
+        "customCommands": {
+          "type": "object",
+          "description": "User defined custom commands.",
+          "additionalProperties": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/externalCommand"
+            }
+          }
+        },
+        "clean": {
+          "type": "array",
+          "description": "User defined extra paths used in the clean command.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "componentType": {
+          "enum": [
+            "durable",
+            "ephemeral",
+            "library"
+          ],
+          "description": "Optional component type, defaults to durable."
+        },
+        "files": {
+          "type": "array",
+          "description": "Initial component files system",
+          "items": {
+            "$ref": "#/definitions/initialComponentFile"
+          }
+        },
+        "plugins": {
+          "type": "array",
+          "description": "Installed plugins for the component",
+          "items": {
+            "$ref": "#/definitions/pluginInstallation"
+          }
+        },
+        "env": {
+          "type": "object",
+          "description": "Environment variables for the component.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "componentProfiles": {
+      "type": "object",
+      "description": "Component definition profiles",
+      "properties": {
+        "profiles": {
+          "type": "object",
+          "description": "Component definition profiles",
+          "additionalProperties": {
+            "$ref": "#/definitions/componentProperties"
+          }
+        },
+        "defaultProfile": {
+          "type": "string",
+          "description": "Default profile"
+        }
+      }
+    },
+    "externalCommand": {
+      "type": "object",
+      "description": "External command with optional inputs and outputs with up-to-date checks",
+      "properties": {
+        "command": {
+          "type": "string",
+          "description": "External command to execute"
+        },
+        "dir": {
+          "type": "string",
+          "description": "Working directory for the command, defaults to the directory of golem.yaml in which the component is defined."
+        },
+        "rmdirs": {
+          "type": "array",
+          "description": "List of directories that should be deleted before running the command, runs before mkdirs.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "mkdirs": {
+          "type": "array",
+          "description": "List of directories that should be created before running the command, runs after rmdirs",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sources": {
+          "type": "array",
+          "description": "Inputs (paths and globs) for the external command",
+          "items": {
+            "type": "string"
+          }
+        },
+        "targets": {
+          "type": "array",
+          "description": "Output (paths and globs) for the external command",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "command"
+      ],
+      "if": {
+        "required": [
+          "sources"
+        ]
+      },
+      "then": {
+        "required": [
+          "targets"
+        ]
+      }
+    },
+    "componentDependency": {
+      "type": "object",
+      "description": "Component dependencies",
+      "oneOf": [
+        {
+          "properties": {
+            "type": {
+              "enum": [
+                "wasm-rpc",
+                "wasm",
+                "wasm-rpc-static"
+              ],
+              "description": "Type of the dependency"
+            },
+            "target": {
+              "type": "string",
+              "description": "Target component name."
+            }
+          },
+          "required": [
+            "type",
+            "target"
+          ]
+        },
+        {
+          "properties": {
+            "type": {
+              "enum": [
+                "wasm"
+              ],
+              "description": "Type of the dependency"
+            },
+            "path": {
+              "type": "string",
+              "description": "Target component WASM path."
+            }
+          },
+          "required": [
+            "type",
+            "path"
+          ]
+        },
+        {
+          "properties": {
+            "type": {
+              "enum": [
+                "wasm"
+              ],
+              "description": "Type of the dependency"
+            },
+            "url": {
+              "type": "string",
+              "description": "Target component remote URL."
+            }
+          },
+          "required": [
+            "type",
+            "url"
+          ]
+        }
+      ]
+    },
+    "initialComponentFile": {
+      "type": "object",
+      "description": "File entry for the initial component file system.",
+      "properties": {
+        "sourcePath": {
+          "type": "string",
+          "description": "Source path for the component file: either a local file or an URL."
+        },
+        "targetPath": {
+          "type": "string",
+          "description": "Target path for the component file, must be an absolute path"
+        },
+        "permissions": {
+          "enum": [
+            "read-only",
+            "read-write"
+          ],
+          "description": "Permission for the component file"
+        }
+      },
+      "required": [
+        "sourcePath",
+        "targetPath"
+      ]
+    },
+    "pluginInstallation": {
+      "type": "object",
+      "description": "Represents an installed plugin",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the plugin"
+        },
+        "version": {
+          "type": "string",
+          "description": "Version of the plugin"
+        },
+        "parameters": {
+          "type": "object",
+          "description": "Key-value pairs for configuring the plugin installation",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "name",
+        "version"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
The schema is already deployed to S3.

Diff with previous version:
```diff
diff -U 3 schema.golem.cloud/app/golem/1.2.2/golem.schema.json schema.golem.cloud/app/golem/1.2.2.1/golem.schema.json
--- schema.golem.cloud/app/golem/1.2.2/golem.schema.json	2025-05-14 08:28:40
+++ schema.golem.cloud/app/golem/1.2.2.1/golem.schema.json	2025-05-19 13:03:07
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft-07/schema#",
-  "$id": "https://schema.golem.cloud/app/golem/1.2.2/golem.schema.json",
+  "$id": "https://schema.golem.cloud/app/golem/1.2.2.1/golem.schema.json",
   "title": "Golem Application Manifest",
   "description": "Golem Application Manifest.",
   "type": "object",
@@ -162,6 +162,7 @@
         },
         "env": {
           "type": "object",
+          "description": "Environment variables for the component.",
           "additionalProperties": {
             "type": "string"
           }
@@ -189,83 +190,56 @@
       "type": "object",
       "description": "External command with optional inputs and outputs with up-to-date checks",
       "properties": {
-      },
-      "oneOf": [
-        {
-          "properties": {
-            "command": {
-              "type": "string",
-              "description": "External command to execute"
-            },
-            "dir": {
-              "type": "string",
-              "description": "Working directory for the command, defaults to the directory of golem.yaml in which the component is defined."
-            },
-            "rmdirs": {
-              "type": "array",
-              "description": "List of directories that should be deleted before running the command, runs before mkdirs.",
-              "items": {
-                "type": "string"
-              }
-            },
-            "mkdirs": {
-              "type": "array",
-              "description": "List of directories that should be created before running the command, runs after rmdirs",
-              "items": {
-                "type": "string"
-              }
-            }
-          },
-          "required": [
-            "command"
-          ]
+        "command": {
+          "type": "string",
+          "description": "External command to execute"
         },
-        {
-          "properties": {
-            "command": {
-              "type": "string",
-              "description": "External command to execute"
-            },
-            "dir": {
-              "type": "string",
-              "description": "Working directory for the command, defaults to the directory of golem.yaml in which the component is defined."
-            },
-            "rmdirs": {
-              "type": "array",
-              "description": "List of directories that should be deleted before running the command, runs before mkdirs.",
-              "items": {
-                "type": "string"
-              }
-            },
-            "mkdirs": {
-              "type": "array",
-              "description": "List of directories that should be created before running the command, runs after rmdirs",
-              "items": {
-                "type": "string"
-              }
-            },
-            "sources": {
-              "type": "array",
-              "description": "Inputs (paths and globs) for the external command",
-              "items": {
-                "type": "string"
-              }
-            },
-            "targets": {
-              "type": "array",
-              "description": "Output (paths and globs) for the external command",
-              "items": {
-                "type": "string"
-              }
-            }
-          },
-          "required": [
-            "command",
-            "sources",
-            "targets"
-          ]
+        "dir": {
+          "type": "string",
+          "description": "Working directory for the command, defaults to the directory of golem.yaml in which the component is defined."
+        },
+        "rmdirs": {
+          "type": "array",
+          "description": "List of directories that should be deleted before running the command, runs before mkdirs.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "mkdirs": {
+          "type": "array",
+          "description": "List of directories that should be created before running the command, runs after rmdirs",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sources": {
+          "type": "array",
+          "description": "Inputs (paths and globs) for the external command",
+          "items": {
+            "type": "string"
+          }
+        },
+        "targets": {
+          "type": "array",
+          "description": "Output (paths and globs) for the external command",
+          "items": {
+            "type": "string"
+          }
         }
-      ]
+      },
+      "required": [
+        "command"
+      ],
+      "if": {
+        "required": [
+          "sources"
+        ]
+      },
+      "then": {
+        "required": [
+          "targets"
+        ]
+      }
     },
     "componentDependency": {
       "type": "object",
```