### PR TITLE
Windows fix for Glob parsing error and fs error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1543,9 +1543,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.24"
+version = "1.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16595d3be041c03b09d08d0858631facccee9221e579704070e6e9e4915d3bc7"
+checksum = "d0fc897dc1e865cc67c0e05a836d9d3f1df3cbe442aa4a9473b18e12624a4951"
 dependencies = [
  "jobserver",
  "libc",
@@ -1644,9 +1644,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.51"
+version = "4.5.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d2267df7f3c8e74e38268887ea5235d4dfadd39bfff2d56ab82d61776be355e"
+checksum = "1a554639e42d0c838336fc4fbedb9e2df3ad1fa4acda149f9126b4ccfcd7900f"
 dependencies = [
  "clap",
 ]
@@ -3533,7 +3533,7 @@ dependencies = [
  "poem",
  "prometheus 0.13.4",
  "regex",
- "reqwest 0.12.17",
+ "reqwest 0.12.19",
  "rustls 0.23.27",
  "serde",
  "sqlx",
@@ -3634,7 +3634,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "reqwest 0.12.17",
+ "reqwest 0.12.19",
  "semver",
  "serde",
  "serde_derive",
@@ -3689,7 +3689,7 @@ dependencies = [
  "golem-wasm-ast 1.3.0-dev.6",
  "golem-wasm-rpc 1.3.0-dev.6",
  "http 1.3.1",
- "reqwest 0.12.17",
+ "reqwest 0.12.19",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -3714,7 +3714,7 @@ dependencies = [
  "golem-wasm-ast 1.3.0-dev.6",
  "golem-wasm-rpc 1.3.0-dev.6",
  "http 1.3.1",
- "reqwest 0.12.17",
+ "reqwest 0.12.19",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -3917,7 +3917,7 @@ dependencies = [
  "poem-openapi-derive",
  "prost 0.13.5",
  "prost-types 0.13.5",
- "reqwest 0.12.17",
+ "reqwest 0.12.19",
  "sanitize-filename",
  "serde",
  "serde_json",
@@ -4057,7 +4057,7 @@ dependencies = [
  "poem-openapi-derive",
  "prometheus 0.13.4",
  "prost-types 0.13.5",
- "reqwest 0.12.17",
+ "reqwest 0.12.19",
  "serde",
  "serde_json",
  "sqlx",
@@ -4587,11 +4587,11 @@ dependencies = [
 
 [[package]]
 name = "headers"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322106e6bd0cba2d5ead589ddb8150a13d7c4217cf80d7c4f682ca994ccc6aa9"
+checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "bytes 1.10.1",
  "headers-core",
  "http 1.3.1",
@@ -4620,12 +4620,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hermit-abi"
@@ -5251,7 +5245,7 @@ version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
- "hermit-abi 0.5.1",
+ "hermit-abi",
  "libc",
  "windows-sys 0.59.0",
 ]
@@ -5757,9 +5751,9 @@ checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "lock_api"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -6245,11 +6239,11 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi",
  "libc",
 ]
 
@@ -6310,7 +6304,7 @@ dependencies = [
  "oci-spec",
  "olpc-cjson",
  "regex",
- "reqwest 0.12.17",
+ "reqwest 0.12.19",
  "serde",
  "serde_json",
  "sha2",
@@ -6421,9 +6415,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.72"
+version = "0.10.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
+checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
 dependencies = [
  "bitflags 2.9.1",
  "cfg-if",
@@ -6453,9 +6447,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.108"
+version = "0.9.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e145e1651e858e820e4860f7b9c5e169bc1d8ce1c86043be79fa7b7634821847"
+checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
 dependencies = [
  "cc",
  "libc",
@@ -6675,9 +6669,9 @@ checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -6685,9 +6679,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
  "cfg-if",
  "libc",
@@ -7118,7 +7112,7 @@ checksum = "b53a684391ad002dd6a596ceb6c74fd004fdce75f4be2e3f615068abbea5fd50"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
- "hermit-abi 0.5.1",
+ "hermit-abi",
  "pin-project-lite",
  "rustix 1.0.7",
  "tracing",
@@ -7219,9 +7213,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.32"
+version = "0.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "664ec5419c51e34154eec046ebcba56312d5a2fc3b09a06da188e1ad21afadf6"
+checksum = "9dee91521343f4c5c6a63edd65e54f31f5c92fe8978c40a4282f8372194c6a7d"
 dependencies = [
  "proc-macro2",
  "syn 2.0.101",
@@ -7929,9 +7923,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.17"
+version = "0.12.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3f27698fc5799d2a281528a908bd874973953ca2e7bc2311637e10c263c723b"
+checksum = "a2f8e5513d63f2e5b386eb5106dc67eaf3f84e95258e210489136b8b92ad6119"
 dependencies = [
  "async-compression",
  "base64 0.22.1",
@@ -9903,9 +9897,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fdb0c213ca27a9f57ab69ddb290fd80d970922355b83ae380b395d3986b8a2e"
+checksum = "5cc2d9e086a412a451384326f521c8123a99a466b329941a9403696bff9b0da2"
 dependencies = [
  "base64 0.22.1",
  "bitflags 2.9.1",
@@ -10443,7 +10437,7 @@ dependencies = [
  "once_cell",
  "pathdiff",
  "ptree",
- "reqwest 0.12.17",
+ "reqwest 0.12.19",
  "secrecy 0.8.0",
  "semver",
  "serde",
@@ -10864,7 +10858,7 @@ dependencies = [
  "etcetera",
  "futures-util",
  "http 1.3.1",
- "reqwest 0.12.17",
+ "reqwest 0.12.19",
  "semver",
  "serde",
  "serde_json",

--- a/golem-cli/src/command_handler/component/ifs.rs
+++ b/golem-cli/src/command_handler/component/ifs.rs
@@ -193,6 +193,7 @@ impl IfsFileManager {
         file_processor: &dyn FileProcessor<R>,
         component_file: &InitialComponentFile,
     ) -> anyhow::Result<Vec<R>> {
+        // if it's a directory, we need to recursively load all files and combine them with their target paths and permissions.
         let source_path = if component_file.source.as_url().scheme() == "file" {
             let url = component_file.source.as_url();
             let path = url.to_file_path().map_err(|_| {

--- a/golem-cli/src/command_handler/component/ifs.rs
+++ b/golem-cli/src/command_handler/component/ifs.rs
@@ -204,8 +204,8 @@ impl IfsFileManager {
 
             if cfg!(windows) {
                 let path_str = path.to_string_lossy().to_string();
-                if path_str.starts_with('/') {
-                    PathBuf::from(&path_str[1..])
+                if let Some(stripped) = path_str.strip_prefix('/') {
+                    PathBuf::from(stripped)
                 } else {
                     path
                 }

--- a/golem-cli/src/command_handler/rib_repl.rs
+++ b/golem-cli/src/command_handler/rib_repl.rs
@@ -86,13 +86,19 @@ impl RibReplHandler {
             })
             .await;
 
+        let prompt = if cfg!(windows) {
+            Some(">>> ".to_string())
+        } else {
+            None
+        };
+
         let mut repl = RibRepl::bootstrap(RibReplConfig {
             history_file: Some(self.ctx.rib_repl_history_file().await?),
             dependency_manager: Arc::new(self.clone()),
             worker_function_invoke: Arc::new(self.clone()),
             printer: None,
             component_source: None,
-            prompt: None,
+            prompt,
         })
         .await?;
 

--- a/golem-cli/src/fs.rs
+++ b/golem-cli/src/fs.rs
@@ -521,8 +521,6 @@ pub fn resolve_relative_glob<P: AsRef<Path>, S: AsRef<str>>(
         }
     }
 
-    // Return the prefix path as-is for file system operations
-    // and the resolved path with normalized separators for glob pattern matching
     Ok((
         base_dir.as_ref().join(prefix_path),
         PathExtra::new(resolved_path)

--- a/golem-cli/src/fs.rs
+++ b/golem-cli/src/fs.rs
@@ -516,9 +516,13 @@ pub fn resolve_relative_glob<P: AsRef<Path>, S: AsRef<str>>(
         }
     }
 
+    // Return the prefix path as-is for file system operations
+    // and the resolved path with normalized separators for glob pattern matching
     Ok((
         base_dir.as_ref().join(prefix_path),
-        PathExtra::new(resolved_path).to_string()?,
+        PathExtra::new(resolved_path)
+            .to_string()?
+            .replace('\\', "/"),
     ))
 }
 

--- a/golem-cli/src/wasm_metadata/names/component.rs
+++ b/golem-cli/src/wasm_metadata/names/component.rs
@@ -12,7 +12,7 @@ pub struct ComponentNames<'a> {
     names: Vec<wasmparser::ComponentName<'a>>,
 }
 
-impl<'a> Debug for ComponentNames<'a> {
+impl Debug for ComponentNames<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ComponentNames")
             .field("component_name", &self.component_name)

--- a/golem-cli/src/wasm_metadata/names/module.rs
+++ b/golem-cli/src/wasm_metadata/names/module.rs
@@ -12,7 +12,7 @@ pub struct ModuleNames<'a> {
     names: Vec<wasmparser::Name<'a>>,
 }
 
-impl<'a> Debug for ModuleNames<'a> {
+impl Debug for ModuleNames<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ModuleNames")
             .field("module_name", &self.module_name)

--- a/golem-cli/src/wasm_metadata/producers.rs
+++ b/golem-cli/src/wasm_metadata/producers.rs
@@ -102,7 +102,7 @@ impl Producers {
     }
 
     /// Iterate through all fields
-    pub fn iter<'a>(&'a self) -> impl Iterator<Item = (&'a String, ProducersField<'a>)> + 'a {
+    pub fn iter(&self) -> impl Iterator<Item = (&String, ProducersField<'_>)> + '_ {
         self.0
             .iter()
             .map(|(name, field)| (name, ProducersField(field)))


### PR DESCRIPTION
closes #228 

glob parsing now correctly uses windows pathing
and fs opens file with write permission so it can edit the update time. 
Fixed ifs path parsing as well.
Fixed indentation issue in window repl

I couldnt find any more errors.  

IFS fails
`error: Error reading local IFS file: /D:/windows/test/data/test.png: The filename, directory name, or volume label syntax is incorrect. (os error 123)`

Repl
The indentation in windows repl, the default blue colored `>>> ` created indentation issue, which leads to
 `>>> wor       ker` , so we override the default blue `>>> ` to a simple `>>> `