### PR TITLE
MCP server mode (/fixes #275)

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,7 @@
+{
+    "servers": {
+        "golem-cli": {
+            "url": "http://localhost:8081/sse"
+        }
+    }
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -968,7 +968,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
 dependencies = [
  "async-trait",
- "axum-core",
+ "axum-core 0.4.5",
  "bytes 1.10.1",
  "futures-util",
  "http 1.3.1",
@@ -977,10 +977,44 @@ dependencies = [
  "hyper 1.6.0",
  "hyper-util",
  "itoa",
- "matchit",
+ "matchit 0.7.3",
  "memchr",
  "mime",
  "multer",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tower 0.5.2",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "021e862c184ae977658b36c4500f7feac3221ca5da43e3f25bd04ab6c79a29b5"
+dependencies = [
+ "axum-core 0.5.2",
+ "bytes 1.10.1",
+ "form_urlencoded",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.6.0",
+ "hyper-util",
+ "itoa",
+ "matchit 0.8.4",
+ "memchr",
+ "mime",
  "percent-encoding",
  "pin-project-lite",
  "rustversion",
@@ -1005,6 +1039,26 @@ dependencies = [
  "async-trait",
  "bytes 1.10.1",
  "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper 1.0.2",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68464cd0412f486726fb3373129ef5d2993f90c34bc2bc1c1e9943b2f4fc7ca6"
+dependencies = [
+ "bytes 1.10.1",
+ "futures-core",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
@@ -3738,7 +3792,7 @@ dependencies = [
  "async-trait",
  "async_zip",
  "auditable-serde",
- "axum",
+ "axum 0.7.9",
  "base64 0.22.1",
  "blake3",
  "bytes 1.10.1",
@@ -3751,10 +3805,12 @@ dependencies = [
  "clap_complete",
  "cli-table",
  "colored",
+ "console",
  "dirs 6.0.0",
  "envsubst",
  "flate2",
  "fs_extra",
+ "futures",
  "futures-util",
  "fuzzy-matcher",
  "golem-client",
@@ -3767,6 +3823,7 @@ dependencies = [
  "golem-wit",
  "heck 0.5.0",
  "humansize",
+ "hyper-util",
  "indexmap 2.9.0",
  "indoc",
  "inquire",
@@ -3783,6 +3840,8 @@ dependencies = [
  "quote",
  "regex",
  "reqwest 0.12.17",
+ "rmcp",
+ "schemars",
  "semver",
  "serde",
  "serde_derive",
@@ -4152,7 +4211,7 @@ dependencies = [
  "async-trait",
  "aws-config",
  "aws-sdk-s3",
- "axum",
+ "axum 0.7.9",
  "bincode",
  "bitflags 2.9.1",
  "bytes 1.10.1",
@@ -4247,6 +4306,8 @@ dependencies = [
  "itertools 0.14.0",
  "nanoid",
  "regex",
+ "rmcp",
+ "schemars",
  "serde",
  "serde_json",
  "strum 0.27.1",
@@ -5022,9 +5083,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c293b6b3d21eca78250dc7dbebd6b9210ec5530e038cbfe0661b5c47ab06e8"
+checksum = "dc2fdfdbff08affe55bb779f33b053aa1fe5dd5b54c257343c17edfa55711bdb"
 dependencies = [
  "base64 0.22.1",
  "bytes 1.10.1",
@@ -6012,6 +6073,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "maybe-owned"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6864,6 +6931,12 @@ name = "parse_arg"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14248cc8eced350e20122a291613de29e4fa129ba2731818c4cdbb44fccd3e55"
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pathdiff"
@@ -8199,6 +8272,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmcp"
+version = "0.1.5"
+source = "git+https://github.com/modelcontextprotocol/rust-sdk?branch=main#e6effb327883d0a8a91f5efbb527194747eee57b"
+dependencies = [
+ "axum 0.8.4",
+ "base64 0.22.1",
+ "bytes 1.10.1",
+ "chrono",
+ "futures",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "paste",
+ "pin-project-lite",
+ "rand 0.9.1",
+ "rmcp-macros",
+ "schemars",
+ "serde",
+ "serde_json",
+ "sse-stream",
+ "thiserror 2.0.12",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tower-service",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "0.1.5"
+source = "git+https://github.com/modelcontextprotocol/rust-sdk?branch=main#e6effb327883d0a8a91f5efbb527194747eee57b"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "ron"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8656,6 +8771,7 @@ version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
+ "chrono",
  "dyn-clone",
  "schemars_derive",
  "serde",
@@ -9485,6 +9601,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sse-stream"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb4dc4d33c68ec1f27d386b5610a351922656e1fdf5c05bbaad930cd1519479a"
+dependencies = [
+ "bytes 1.10.1",
+ "futures-util",
+ "http-body 1.0.1",
+ "http-body-util",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10101,7 +10230,7 @@ checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
 dependencies = [
  "async-stream",
  "async-trait",
- "axum",
+ "axum 0.7.9",
  "base64 0.22.1",
  "bytes 1.10.1",
  "flate2",
@@ -11910,7 +12039,7 @@ dependencies = [
  "windows-interface 0.59.1",
  "windows-link",
  "windows-result 0.3.4",
- "windows-strings 0.4.2",
+ "windows-strings",
 ]
 
 [[package]]
@@ -11965,13 +12094,13 @@ checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
 
 [[package]]
 name = "windows-registry"
-version = "0.4.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
+checksum = "b3bab093bdd303a1240bb99b8aba8ea8a69ee19d34c9e2ef9594e708a4878820"
 dependencies = [
+ "windows-link",
  "windows-result 0.3.4",
- "windows-strings 0.3.1",
- "windows-targets 0.53.0",
+ "windows-strings",
 ]
 
 [[package]]
@@ -11988,15 +12117,6 @@ name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
 dependencies = [
  "windows-link",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,9 @@ prometheus = "0.13.4"
 quote = "1.0.37"
 regex = "1.11.1"
 reqwest = { version = "0.12.13", features = ["blocking"] }
+rmcp = { git = "https://github.com/modelcontextprotocol/rust-sdk", branch = "main", features=["transport-io", "macros", "server", "transport-sse-server", "transport-streamable-http-server", "transport-streamable-http-server-session"]}
 rustls = "0.23.23"
+schemars = { version = "0.8.0" }
 semver = "1.0.23"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/golem-cli/Cargo.toml
+++ b/golem-cli/Cargo.toml
@@ -59,14 +59,17 @@ clap-verbosity-flag = { workspace = true }
 clap_complete = { workspace = true }
 cli-table = { workspace = true }
 colored = { workspace = true }
+console = "0.15.11"
 dirs = { workspace = true }
 envsubst = { workspace = true }
 flate2 = { version = "1.1.0" }
 fs_extra = { workspace = true }
+futures = { workspace = true }
 futures-util = { workspace = true }
 fuzzy-matcher = { workspace = true }
 heck = { workspace = true }
 humansize = { workspace = true }
+hyper-util = "0.1.14"
 indexmap = { workspace = true }
 indoc = { workspace = true }
 inquire = { workspace = true }
@@ -82,6 +85,8 @@ proc-macro2 = { workspace = true }
 quote = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true }
+rmcp = { workspace= true }
+schemars= { workspace= true }
 semver = { workspace = true }
 serde = { workspace = true }
 serde_derive = "1.0.219"

--- a/golem-cli/src/app/build/external_command.rs
+++ b/golem-cli/src/app/build/external_command.rs
@@ -17,7 +17,10 @@ use crate::app::build::{delete_path_logged, is_up_to_date, valid_env_vars};
 use crate::app::context::ApplicationContext;
 use crate::app::error::CustomCommandError;
 use crate::fs::compile_and_collect_globs;
-use crate::log::{log_action, log_skipping_up_to_date, LogColorize, LogIndent};
+use crate::log::{
+    get_log_output, log_action, log_skipping_up_to_date, store_mcp_tool_output,
+    LogColorize, LogIndent, Output,
+};
 use crate::model::app_raw;
 use anyhow::{anyhow, Context};
 use std::collections::HashMap;
@@ -184,18 +187,33 @@ pub fn execute_external_command(
         let result = Command::new(command_tokens[0].clone())
             .args(command_tokens.iter().skip(1))
             .current_dir(build_dir)
-            .status()
+            .output()
             .with_context(|| "Failed to execute command".to_string())?;
+        let status = result.status;
 
-        if result.success() {
+        if status.success() {
+            if matches!(get_log_output(), Output::Mcp(_)) {
+                use std::borrow::Cow;
+                let out_str = format!(
+                    "Command execution went fine. stdout: {}, stderr: {}",
+                    String::from_utf8_lossy(&result.stdout),
+                    String::from_utf8_lossy(&result.stderr)
+                );
+                store_mcp_tool_output("", Cow::Borrowed(&out_str));
+            }
             Ok(())
         } else {
             Err(anyhow!(format!(
-                "Command failed with exit code: {}",
-                result
+                "Command failed with exit code: {} and output: {}",
+                status
                     .code()
                     .map(|code| code.to_string().log_color_error_highlight().to_string())
-                    .unwrap_or_else(|| "?".to_string())
+                    .unwrap_or_else(|| "?".to_string()),
+                format!(
+                    "stdout: {}, stderr: {}",
+                    String::from_utf8_lossy(&result.stdout),
+                    String::from_utf8_lossy(&result.stderr)
+                )
             )))
         }
     })())

--- a/golem-cli/src/command.rs
+++ b/golem-cli/src/command.rs
@@ -597,7 +597,7 @@ pub mod shared_args {
     #[derive(Debug, Args, Serialize, Deserialize, schemars::JsonSchema)]
     pub struct ComponentOptionalComponentNames {
         // DO NOT ADD EMPTY LINES TO THE DOC COMMENT
-        /// Optional component names, if not specified components are selected based on the current directory
+        /// Optional component names, if not specified components or asks for all compoennets,  make it empty vector and are selected based on the current directory
         /// Accepted formats:
         ///   - <COMPONENT>
         ///   - <PROJECT>/<COMPONENT>
@@ -676,7 +676,6 @@ pub mod shared_args {
         /// Update existing workers with auto or manual update mode
         #[clap(long, value_name = "UPDATE_MODE", short, conflicts_with_all = ["redeploy_workers", "redeploy_all"], num_args = 0..=1
         )]
-        #[schemars(default="default_worker_update_mode")]
         pub update_workers: Option<WorkerUpdateMode>,
         /// Delete and recreate existing workers
         #[clap(long, conflicts_with_all = ["update_workers"])]
@@ -1822,9 +1821,10 @@ pub mod server {
 pub mod mcp_server {
     use clap::Subcommand;
 
-    #[derive(Debug, Clone, clap::ValueEnum)]
+    #[derive(Debug, Clone, clap::ValueEnum, Default)]
     pub enum Transport {
         StreamableHttp,
+        #[default]
         Sse,
     }
 

--- a/golem-cli/src/command.rs
+++ b/golem-cli/src/command.rs
@@ -16,6 +16,7 @@ use crate::command::api::ApiSubcommand;
 use crate::command::app::AppSubcommand;
 use crate::command::cloud::CloudSubcommand;
 use crate::command::component::ComponentSubcommand;
+use crate::command::mcp_server::McpServerSubcommand;
 use crate::command::plugin::PluginSubcommand;
 use crate::command::profile::ProfileSubcommand;
 use crate::command::worker::WorkerSubcommand;
@@ -545,6 +546,12 @@ pub enum GolemCliSubcommand {
         /// Selects shell
         shell: clap_complete::Shell,
     },
+    #[command(alias = "mcp")]
+    /// Mcp Server for golem-cli
+    McpServer {
+        #[clap(subcommand)]
+        subcommand: McpServerSubcommand,
+    },
 }
 
 pub mod shared_args {
@@ -555,6 +562,8 @@ pub mod shared_args {
     };
     use clap::Args;
     use golem_templates::model::GuestLanguage;
+    use rmcp::schemars;
+    use serde::{Deserialize, Serialize};
 
     pub type ComponentTemplateName = String;
     pub type NewWorkerArgument = String;
@@ -573,7 +582,7 @@ pub mod shared_args {
         pub component_name: ComponentName,
     }
 
-    #[derive(Debug, Args)]
+    #[derive(Debug, Args, Serialize, Deserialize, schemars::JsonSchema)]
     pub struct ComponentOptionalComponentName {
         // DO NOT ADD EMPTY LINES TO THE DOC COMMENT
         /// Optional component name, if not specified component is selected based on the current directory.
@@ -585,7 +594,7 @@ pub mod shared_args {
         pub component_name: Option<ComponentName>,
     }
 
-    #[derive(Debug, Args)]
+    #[derive(Debug, Args, Serialize, Deserialize, schemars::JsonSchema)]
     pub struct ComponentOptionalComponentNames {
         // DO NOT ADD EMPTY LINES TO THE DOC COMMENT
         /// Optional component names, if not specified components are selected based on the current directory
@@ -597,7 +606,7 @@ pub mod shared_args {
         pub component_name: Vec<ComponentName>,
     }
 
-    #[derive(Debug, Args)]
+    #[derive(Debug, Args, Serialize, Deserialize, schemars::JsonSchema)]
     pub struct AppOptionalComponentNames {
         // DO NOT ADD EMPTY LINES TO THE DOC COMMENT
         /// Optional component names, if not specified all components are selected.
@@ -614,23 +623,33 @@ pub mod shared_args {
         pub language: GuestLanguage,
     }
 
-    #[derive(Debug, Args)]
+    #[derive(Debug, Args, Default, Serialize, Deserialize, schemars::JsonSchema)]
     pub struct ForceBuildArg {
         /// When set to true will skip modification time based up-to-date checks, defaults to false
         #[clap(long, default_value = "false")]
+        #[schemars(default="default_force_build_arg")]
         pub force_build: bool,
     }
 
-    #[derive(Debug, Args)]
+    fn default_force_build_arg() -> bool {
+        false
+    }
+
+    #[derive(Debug, Args, Default, Serialize, Deserialize, schemars::JsonSchema)]
     pub struct BuildArgs {
         /// Select specific build step(s)
         #[clap(long, short)]
+        #[schemars(default="default_build_args_steps")]
         pub step: Vec<AppBuildStep>,
         #[command(flatten)]
         pub force_build: ForceBuildArg,
     }
 
-    #[derive(Debug, Args)]
+    fn default_build_args_steps() -> Vec<AppBuildStep> {
+        vec![]
+    }
+
+    #[derive(Debug, Args, Serialize, Deserialize, schemars::JsonSchema)]
     pub struct WorkerNameArg {
         // DO NOT ADD EMPTY LINES TO THE DOC COMMENT
         /// Worker name, accepted formats:
@@ -642,7 +661,7 @@ pub mod shared_args {
         pub worker_name: WorkerName,
     }
 
-    #[derive(Debug, Args)]
+    #[derive(Debug, Args, Serialize, Deserialize, schemars::JsonSchema)]
     pub struct StreamArgs {
         /// Hide log levels in stream output
         #[clap(long, short = 'L')]
@@ -652,11 +671,12 @@ pub mod shared_args {
         pub stream_no_timestamp: bool,
     }
 
-    #[derive(Debug, Args)]
+    #[derive(Debug, Args, Default, Serialize, Deserialize, schemars::JsonSchema)]
     pub struct UpdateOrRedeployArgs {
         /// Update existing workers with auto or manual update mode
         #[clap(long, value_name = "UPDATE_MODE", short, conflicts_with_all = ["redeploy_workers", "redeploy_all"], num_args = 0..=1
         )]
+        #[schemars(default="default_worker_update_mode")]
         pub update_workers: Option<WorkerUpdateMode>,
         /// Delete and recreate existing workers
         #[clap(long, conflicts_with_all = ["update_workers"])]
@@ -695,7 +715,7 @@ pub mod shared_args {
         }
     }
 
-    #[derive(Debug, Args)]
+    #[derive(Debug, Args, Serialize, Deserialize, schemars::JsonSchema)]
     pub struct ProjectArg {
         // DO NOT ADD EMPTY LINES TO THE DOC COMMENT
         /// Project, accepted formats:
@@ -705,7 +725,7 @@ pub mod shared_args {
         pub project: ProjectReference,
     }
 
-    #[derive(Debug, Args)]
+    #[derive(Debug, Args, Serialize, Deserialize, schemars::JsonSchema)]
     pub struct ProjectOptionalFlagArg {
         // DO NOT ADD EMPTY LINES TO THE DOC COMMENT
         /// Project, accepted formats:
@@ -715,14 +735,14 @@ pub mod shared_args {
         pub project: Option<ProjectReference>,
     }
 
-    #[derive(Debug, Args)]
+    #[derive(Debug, Args, Serialize, Deserialize, schemars::JsonSchema)]
     pub struct AccountIdOptionalArg {
         /// Account ID
         #[arg(long)]
         pub account_id: Option<AccountId>,
     }
 
-    #[derive(clap::Args, Debug, Clone)]
+    #[derive(clap::Args, Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
     pub struct PluginScopeArgs {
         /// Global scope (plugin available for all components)
         #[arg(long, conflicts_with_all=["account", "project", "component"])]
@@ -1796,6 +1816,30 @@ pub mod server {
         },
         /// Clean the local server data directory
         Clean,
+    }
+}
+
+pub mod mcp_server {
+    use clap::Subcommand;
+
+    #[derive(Debug, Clone, clap::ValueEnum)]
+    pub enum Transport {
+        StreamableHttp,
+        Sse,
+    }
+
+    #[derive(Debug, Subcommand)]
+    pub enum McpServerSubcommand {
+        /// Run the MCP server
+        Run {
+            /// server port to serve the MCP API on (localhost), defaults t0 8080
+            #[clap(long)]
+            port: Option<u16>,
+            #[clap(long)]
+            timeout: Option<u64>,
+            #[clap(long, value_enum)]
+            transport: Option<Transport>,
+        },
     }
 }
 

--- a/golem-cli/src/command.rs
+++ b/golem-cli/src/command.rs
@@ -558,7 +558,7 @@ pub mod shared_args {
     use crate::model::app::AppBuildStep;
     use crate::model::AccountId;
     use crate::model::{
-        ComponentName, ProjectName, ProjectReference, WorkerName, WorkerUpdateMode,
+        ComponentName, ProjectName, ProjectReference, WorkerName, WorkerUpdateMode, default_worker_update_mode
     };
     use clap::Args;
     use golem_templates::model::GuestLanguage;

--- a/golem-cli/src/command.rs
+++ b/golem-cli/src/command.rs
@@ -558,7 +558,7 @@ pub mod shared_args {
     use crate::model::app::AppBuildStep;
     use crate::model::AccountId;
     use crate::model::{
-        ComponentName, ProjectName, ProjectReference, WorkerName, WorkerUpdateMode, default_worker_update_mode
+        ComponentName, ProjectName, ProjectReference, WorkerName, WorkerUpdateMode
     };
     use clap::Args;
     use golem_templates::model::GuestLanguage;

--- a/golem-cli/src/command_handler/api/cloud/certificate.rs
+++ b/golem-cli/src/command_handler/api/cloud/certificate.rs
@@ -63,7 +63,7 @@ impl ApiCloudCertificateCommandHandler {
         }
     }
 
-    async fn cmd_get(
+    pub async fn cmd_get(
         &self,
         project: ProjectReference,
         certificate_id: Option<Uuid>,
@@ -93,7 +93,7 @@ impl ApiCloudCertificateCommandHandler {
         Ok(())
     }
 
-    async fn cmd_new(
+    pub async fn cmd_new(
         &self,
         project: ProjectReference,
         domain_name: String,
@@ -132,7 +132,7 @@ impl ApiCloudCertificateCommandHandler {
         Ok(())
     }
 
-    async fn cmd_delete(
+    pub async fn cmd_delete(
         &self,
         project: ProjectReference,
         certificate_id: Uuid,

--- a/golem-cli/src/command_handler/api/cloud/domain.rs
+++ b/golem-cli/src/command_handler/api/cloud/domain.rs
@@ -47,7 +47,7 @@ impl ApiCloudDomainCommandHandler {
         }
     }
 
-    async fn cmd_get(&self, project_reference: ProjectReference) -> anyhow::Result<()> {
+    pub async fn cmd_get(&self, project_reference: ProjectReference) -> anyhow::Result<()> {
         let domains = self
             .ctx
             .golem_clients()
@@ -70,7 +70,7 @@ impl ApiCloudDomainCommandHandler {
         Ok(())
     }
 
-    async fn cmd_new(
+    pub async fn cmd_new(
         &self,
         project_reference: ProjectReference,
         domain_name: String,
@@ -98,7 +98,7 @@ impl ApiCloudDomainCommandHandler {
         Ok(())
     }
 
-    async fn cmd_delete(
+    pub async fn cmd_delete(
         &self,
         project_reference: ProjectReference,
         domain_name: String,

--- a/golem-cli/src/command_handler/api/definition.rs
+++ b/golem-cli/src/command_handler/api/definition.rs
@@ -74,7 +74,7 @@ impl ApiDefinitionCommandHandler {
         }
     }
 
-    async fn cmd_deploy(
+    pub async fn cmd_deploy(
         &self,
         name: Option<HttpApiDefinitionName>,
         update_or_redeploy: UpdateOrRedeployArgs,
@@ -150,7 +150,7 @@ impl ApiDefinitionCommandHandler {
         }
     }
 
-    async fn cmd_get(
+    pub async fn cmd_get(
         &self,
         project: ProjectOptionalFlagArg,
         api_def_id: ApiDefinitionId,
@@ -179,7 +179,7 @@ impl ApiDefinitionCommandHandler {
         }
     }
 
-    async fn cmd_list(
+    pub async fn cmd_list(
         &self,
         project: ProjectOptionalFlagArg,
         api_definition_id: Option<ApiDefinitionId>,
@@ -211,7 +211,7 @@ impl ApiDefinitionCommandHandler {
         Ok(())
     }
 
-    async fn cmd_delete(
+    pub async fn cmd_delete(
         &self,
         project: ProjectOptionalFlagArg,
         api_def_id: ApiDefinitionId,

--- a/golem-cli/src/command_handler/api/deployment.rs
+++ b/golem-cli/src/command_handler/api/deployment.rs
@@ -64,7 +64,7 @@ impl ApiDeploymentCommandHandler {
         }
     }
 
-    async fn cmd_deploy(
+    pub async fn cmd_deploy(
         &self,
         host_or_site: Option<String>,
         update_or_redeploy: UpdateOrRedeployArgs,
@@ -129,7 +129,11 @@ impl ApiDeploymentCommandHandler {
         Ok(())
     }
 
-    async fn cmd_get(&self, project: ProjectOptionalFlagArg, site: String) -> anyhow::Result<()> {
+    pub async fn cmd_get(
+        &self,
+        project: ProjectOptionalFlagArg,
+        site: String,
+    ) -> anyhow::Result<()> {
         let project = self
             .ctx
             .cloud_project_handler()
@@ -145,7 +149,7 @@ impl ApiDeploymentCommandHandler {
         Ok(())
     }
 
-    async fn cmd_list(
+    pub async fn cmd_list(
         &self,
         project: ProjectOptionalFlagArg,
         definition: Option<ApiDefinitionId>,
@@ -189,7 +193,7 @@ impl ApiDeploymentCommandHandler {
         Ok(())
     }
 
-    async fn cmd_delete(
+    pub async fn cmd_delete(
         &self,
         project: ProjectOptionalFlagArg,
         site: String,

--- a/golem-cli/src/command_handler/api/security_scheme.rs
+++ b/golem-cli/src/command_handler/api/security_scheme.rs
@@ -62,7 +62,7 @@ impl ApiSecuritySchemeCommandHandler {
         }
     }
 
-    async fn cmd_create(
+    pub async fn cmd_create(
         &self,
         project: ProjectOptionalFlagArg,
         scheme_identifier: String,
@@ -112,7 +112,7 @@ impl ApiSecuritySchemeCommandHandler {
         Ok(())
     }
 
-    async fn cmd_get(
+    pub async fn cmd_get(
         &self,
         project: ProjectOptionalFlagArg,
         security_scheme_id: String,

--- a/golem-cli/src/command_handler/app.rs
+++ b/golem-cli/src/command_handler/app.rs
@@ -87,7 +87,7 @@ impl AppCommandHandler {
         }
     }
 
-    async fn cmd_new(
+    pub async fn cmd_new(
         &self,
         application_name: Option<String>,
         languages: Vec<GuestLanguage>,
@@ -263,7 +263,7 @@ impl AppCommandHandler {
         Ok(())
     }
 
-    async fn cmd_build(
+    pub async fn cmd_build(
         &self,
         component_name: AppOptionalComponentNames,
         build_args: BuildArgs,
@@ -276,7 +276,7 @@ impl AppCommandHandler {
         .await
     }
 
-    async fn cmd_clean(&self, component_name: AppOptionalComponentNames) -> anyhow::Result<()> {
+    pub async fn cmd_clean(&self, component_name: AppOptionalComponentNames) -> anyhow::Result<()> {
         self.clean(
             component_name.component_name,
             &ApplicationComponentSelectMode::All,
@@ -284,7 +284,7 @@ impl AppCommandHandler {
         .await
     }
 
-    async fn cmd_deploy(
+    pub async fn cmd_deploy(
         &self,
         component_name: AppOptionalComponentNames,
         force_build: ForceBuildArg,
@@ -294,7 +294,7 @@ impl AppCommandHandler {
             .await
     }
 
-    async fn cmd_custom_command(&self, command: Vec<String>) -> anyhow::Result<()> {
+    pub async fn cmd_custom_command(&self, command: Vec<String>) -> anyhow::Result<()> {
         if command.len() != 1 {
             bail!(
                 "Expected exactly one custom subcommand, got: {}",
@@ -345,7 +345,7 @@ impl AppCommandHandler {
         Ok(())
     }
 
-    async fn cmd_update_workers(
+    pub async fn cmd_update_workers(
         &self,
         component_names: Vec<ComponentName>,
         update_mode: WorkerUpdateMode,
@@ -362,7 +362,7 @@ impl AppCommandHandler {
         Ok(())
     }
 
-    async fn cmd_redeploy_workers(
+    pub async fn cmd_redeploy_workers(
         &self,
         component_names: Vec<ComponentName>,
     ) -> anyhow::Result<()> {
@@ -378,7 +378,10 @@ impl AppCommandHandler {
         Ok(())
     }
 
-    async fn cmd_diagnose(&self, component_names: AppOptionalComponentNames) -> anyhow::Result<()> {
+    pub async fn cmd_diagnose(
+        &self,
+        component_names: AppOptionalComponentNames,
+    ) -> anyhow::Result<()> {
         self.diagnose(
             component_names.component_name,
             &ApplicationComponentSelectMode::All,

--- a/golem-cli/src/command_handler/cloud/account/grant.rs
+++ b/golem-cli/src/command_handler/cloud/account/grant.rs
@@ -45,7 +45,7 @@ impl CloudAccountGrantCommandHandler {
         }
     }
 
-    async fn cmd_get(&self, account_id: Option<AccountId>) -> anyhow::Result<()> {
+    pub async fn cmd_get(&self, account_id: Option<AccountId>) -> anyhow::Result<()> {
         let roles = self
             .ctx
             .golem_clients()
@@ -67,7 +67,7 @@ impl CloudAccountGrantCommandHandler {
         Ok(())
     }
 
-    async fn cmd_new(&self, account_id: Option<AccountId>, role: Role) -> anyhow::Result<()> {
+    pub async fn cmd_new(&self, account_id: Option<AccountId>, role: Role) -> anyhow::Result<()> {
         self.ctx
             .golem_clients()
             .await?
@@ -89,7 +89,11 @@ impl CloudAccountGrantCommandHandler {
         Ok(())
     }
 
-    async fn cmd_delete(&self, account_id: Option<AccountId>, role: Role) -> anyhow::Result<()> {
+    pub async fn cmd_delete(
+        &self,
+        account_id: Option<AccountId>,
+        role: Role,
+    ) -> anyhow::Result<()> {
         self.ctx
             .golem_clients()
             .await?

--- a/golem-cli/src/command_handler/cloud/account/mod.rs
+++ b/golem-cli/src/command_handler/cloud/account/mod.rs
@@ -65,14 +65,14 @@ impl CloudAccountCommandHandler {
         }
     }
 
-    async fn cmd_get(&self, account_id: Option<AccountId>) -> anyhow::Result<()> {
+    pub async fn cmd_get(&self, account_id: Option<AccountId>) -> anyhow::Result<()> {
         let account = self.get(account_id).await?;
         self.ctx.log_handler().log_view(&AccountGetView(account));
 
         Ok(())
     }
 
-    async fn cmd_update(
+    pub async fn cmd_update(
         &self,
         account_id: Option<AccountId>,
         account_name: Option<String>,
@@ -105,7 +105,7 @@ impl CloudAccountCommandHandler {
         Ok(())
     }
 
-    async fn cmd_new(&self, account_name: String, account_email: String) -> anyhow::Result<()> {
+    pub async fn cmd_new(&self, account_name: String, account_email: String) -> anyhow::Result<()> {
         let account = self
             .ctx
             .golem_clients()
@@ -123,7 +123,7 @@ impl CloudAccountCommandHandler {
         Ok(())
     }
 
-    async fn cmd_delete(&self, account_id: Option<AccountId>) -> anyhow::Result<()> {
+    pub async fn cmd_delete(&self, account_id: Option<AccountId>) -> anyhow::Result<()> {
         let account = self.get(account_id).await?;
         if !self
             .ctx

--- a/golem-cli/src/command_handler/cloud/project/plugin.rs
+++ b/golem-cli/src/command_handler/cloud/project/plugin.rs
@@ -70,7 +70,7 @@ impl CloudProjectPluginCommandHandler {
         }
     }
 
-    async fn cmd_install(
+    pub async fn cmd_install(
         &self,
         project_reference: ProjectReference,
         plugin_name: String,
@@ -112,7 +112,7 @@ impl CloudProjectPluginCommandHandler {
         Ok(())
     }
 
-    async fn cmd_get(&self, project: ProjectReference) -> anyhow::Result<()> {
+    pub async fn cmd_get(&self, project: ProjectReference) -> anyhow::Result<()> {
         let project = self
             .ctx
             .cloud_project_handler()
@@ -133,7 +133,7 @@ impl CloudProjectPluginCommandHandler {
         Ok(())
     }
 
-    async fn cmd_update(
+    pub async fn cmd_update(
         &self,
         project_reference: ProjectReference,
         plugin_installation_id: PluginInstallationId,
@@ -171,7 +171,7 @@ impl CloudProjectPluginCommandHandler {
         Ok(())
     }
 
-    async fn cmd_uninstall(
+    pub async fn cmd_uninstall(
         &self,
         project_reference: ProjectReference,
         plugin_installation_id: PluginInstallationId,

--- a/golem-cli/src/command_handler/cloud/project/policy.rs
+++ b/golem-cli/src/command_handler/cloud/project/policy.rs
@@ -41,7 +41,7 @@ impl CloudProjectPolicyCommandHandler {
         }
     }
 
-    async fn cmd_new(
+    pub async fn cmd_new(
         &self,
         policy_name: String,
         actions: Vec<ProjectPermission>,
@@ -67,7 +67,7 @@ impl CloudProjectPolicyCommandHandler {
         Ok(())
     }
 
-    async fn cmd_get(&self, policy_id: ProjectPolicyId) -> anyhow::Result<()> {
+    pub async fn cmd_get(&self, policy_id: ProjectPolicyId) -> anyhow::Result<()> {
         let policy = self
             .ctx
             .golem_clients()

--- a/golem-cli/src/command_handler/cloud/token.rs
+++ b/golem-cli/src/command_handler/cloud/token.rs
@@ -41,7 +41,7 @@ impl CloudTokenCommandHandler {
         }
     }
 
-    async fn cmd_list(&self) -> anyhow::Result<()> {
+    pub async fn cmd_list(&self) -> anyhow::Result<()> {
         let clients = self.ctx.golem_clients().await?;
 
         let tokens = clients
@@ -55,7 +55,7 @@ impl CloudTokenCommandHandler {
         Ok(())
     }
 
-    async fn cmd_new(&self, expires_at: DateTime<Utc>) -> anyhow::Result<()> {
+    pub async fn cmd_new(&self, expires_at: DateTime<Utc>) -> anyhow::Result<()> {
         let clients = self.ctx.golem_clients().await?;
 
         let token = clients
@@ -69,7 +69,7 @@ impl CloudTokenCommandHandler {
         Ok(())
     }
 
-    async fn cmd_delete(&self, token_id: TokenId) -> anyhow::Result<()> {
+    pub async fn cmd_delete(&self, token_id: TokenId) -> anyhow::Result<()> {
         let clients = self.ctx.golem_clients().await?;
 
         clients

--- a/golem-cli/src/command_handler/component/mod.rs
+++ b/golem-cli/src/command_handler/component/mod.rs
@@ -148,7 +148,7 @@ impl ComponentCommandHandler {
         }
     }
 
-    async fn cmd_new(
+    pub async fn cmd_new(
         &self,
         template: Option<ComponentTemplateName>,
         component_package_name: Option<PackageName>,
@@ -240,7 +240,7 @@ impl ComponentCommandHandler {
         Ok(())
     }
 
-    async fn cmd_build(
+    pub async fn cmd_build(
         &self,
         component_name: ComponentOptionalComponentNames,
         build_args: BuildArgs,
@@ -255,7 +255,7 @@ impl ComponentCommandHandler {
             .await
     }
 
-    async fn cmd_clean(
+    pub async fn cmd_clean(
         &self,
         component_name: ComponentOptionalComponentNames,
     ) -> anyhow::Result<()> {
@@ -268,7 +268,7 @@ impl ComponentCommandHandler {
             .await
     }
 
-    async fn cmd_deploy(
+    pub async fn cmd_deploy(
         &self,
         component_name: ComponentOptionalComponentNames,
         force_build: ForceBuildArg,
@@ -290,7 +290,7 @@ impl ComponentCommandHandler {
         Ok(())
     }
 
-    fn cmd_templates(&self, filter: Option<String>) {
+    pub fn cmd_templates(&self, filter: Option<String>) {
         match filter {
             Some(filter) => {
                 if let Some(language) = GuestLanguage::from_string(filter.clone()) {
@@ -307,7 +307,7 @@ impl ComponentCommandHandler {
         }
     }
 
-    async fn cmd_list(&self, component_name: Option<ComponentName>) -> anyhow::Result<()> {
+    pub async fn cmd_list(&self, component_name: Option<ComponentName>) -> anyhow::Result<()> {
         let show_sensitive = self.ctx.show_sensitive();
 
         let selected_component_names = self
@@ -384,7 +384,7 @@ impl ComponentCommandHandler {
         Ok(())
     }
 
-    async fn cmd_get(
+    pub async fn cmd_get(
         &self,
         component_name: Option<ComponentName>,
         version: Option<u64>,
@@ -490,7 +490,7 @@ impl ComponentCommandHandler {
         Ok(())
     }
 
-    async fn cmd_update_workers(
+    pub async fn cmd_update_workers(
         &self,
         component_name: Option<ComponentName>,
         update_mode: WorkerUpdateMode,
@@ -504,7 +504,7 @@ impl ComponentCommandHandler {
         Ok(())
     }
 
-    async fn cmd_redeploy_workers(
+    pub async fn cmd_redeploy_workers(
         &self,
         component_name: Option<ComponentName>,
     ) -> anyhow::Result<()> {
@@ -516,7 +516,7 @@ impl ComponentCommandHandler {
         Ok(())
     }
 
-    async fn cmd_diagnose(
+    pub async fn cmd_diagnose(
         &self,
         component_names: ComponentOptionalComponentNames,
     ) -> anyhow::Result<()> {
@@ -529,7 +529,7 @@ impl ComponentCommandHandler {
             .await
     }
 
-    async fn cmd_add_dependency(
+    pub async fn cmd_add_dependency(
         &self,
         component_name: Option<ComponentName>,
         target_component_name: Option<ComponentName>,

--- a/golem-cli/src/command_handler/component/plugin.rs
+++ b/golem-cli/src/command_handler/component/plugin.rs
@@ -86,7 +86,7 @@ impl ComponentPluginCommandHandler {
         }
     }
 
-    async fn cmd_install(
+    pub async fn cmd_install(
         &self,
         component_name: Option<ComponentName>,
         plugin_name: String,
@@ -160,7 +160,7 @@ impl ComponentPluginCommandHandler {
         Ok(())
     }
 
-    async fn cmd_get(
+    pub async fn cmd_get(
         &self,
         component_name: Option<ComponentName>,
         version: Option<u64>,
@@ -210,7 +210,7 @@ impl ComponentPluginCommandHandler {
         Ok(())
     }
 
-    async fn cmd_update(
+    pub async fn cmd_update(
         &self,
         component_name: Option<ComponentName>,
         plugin_installation_id: PluginInstallationId,
@@ -275,7 +275,7 @@ impl ComponentPluginCommandHandler {
         Ok(())
     }
 
-    async fn cmd_uninstall(
+    pub async fn cmd_uninstall(
         &self,
         component_name: Option<ComponentName>,
         plugin_installation_id: PluginInstallationId,

--- a/golem-cli/src/command_handler/mcp_server/handler.rs
+++ b/golem-cli/src/command_handler/mcp_server/handler.rs
@@ -1,0 +1,123 @@
+use std::{fs, future::Future, path::Path };
+
+use rmcp::{
+    model::{
+        Implementation, ListResourcesResult, PaginatedRequestParam, ProtocolVersion, RawResource,
+        ReadResourceRequestParam, ReadResourceResult, Resource, ResourceContents,
+        ServerCapabilities, ServerInfo,
+    },
+    service::RequestContext,
+    tool_handler, Error, RoleServer, ServerHandler,
+};
+
+use crate::command_handler::mcp_server::GolemCliMcpServer;
+
+#[tool_handler]
+impl ServerHandler for GolemCliMcpServer {
+    fn list_resources(
+        &self,
+        _request: Option<PaginatedRequestParam>,
+        _context: RequestContext<RoleServer>,
+    ) -> impl Future<Output = Result<ListResourcesResult, Error>> + Send + '_ {
+        std::future::ready(Ok(ListResourcesResult {
+            next_cursor: None,
+            resources: {
+                let mut resources = Vec::new();
+                let golem_app_manifest_pattern =
+                    regex::Regex::new(r"^golem\.(yaml|json)$").unwrap();
+                let file_pattern = regex::Regex::new(
+                    r"^golem\.(yaml|json)$|^components-[^/]+/.+/golem\.(yaml|json)$",
+                )
+                .unwrap();
+                for entry in walkdir::WalkDir::new(".")
+                    .into_iter()
+                    .filter_map(Result::ok)
+                {
+                    let path = entry.path();
+
+                    if path.is_file() {
+                        if let Ok(rel_path) = path.strip_prefix(".") {
+                            let rel_path_str = rel_path.to_string_lossy();
+
+                            if file_pattern.is_match(&rel_path_str) {
+                                let resource = {
+                                    let is_path_golem_app_manifest =
+                                        golem_app_manifest_pattern.is_match(&rel_path_str);
+                                    let name = if is_path_golem_app_manifest {
+                                        "golem app manifest".to_string()
+                                    } else {
+                                        path.parent()
+                                            .and_then(|p| p.file_name())
+                                            .and_then(|n| n.to_str())
+                                            .unwrap_or_default()
+                                            .to_string()
+                                    };
+                                    let uri = path.to_string_lossy().to_string();
+                                    let description = if is_path_golem_app_manifest {
+                                        Some("Manifest file for entire golem app".to_string())
+                                    } else {
+                                        Some(format!(
+                                            "Manifest file for Component - {}",
+                                            path.parent().unwrap().to_string_lossy()
+                                        ))
+                                    };
+                                    let mime_type = None;
+                                    let size = std::fs::metadata(path).ok().map(|m| m.len() as u32);
+                                    Resource {
+                                        raw: RawResource {
+                                            uri,
+                                            name,
+                                            description,
+                                            mime_type,
+                                            size,
+                                        },
+                                        annotations: None,
+                                    }
+                                };
+                                resources.push(resource);
+                            }
+                        }
+                    }
+                }
+                resources
+            },
+        }))
+    }
+
+    fn read_resource(
+        &self,
+        request: ReadResourceRequestParam,
+        _context: RequestContext<RoleServer>,
+    ) -> impl Future<Output = Result<ReadResourceResult, Error>> + Send + '_ {
+        std::future::ready(
+            // read file from request.uri path and send as content
+            match fs::read_to_string(Path::new(&request.uri)) {
+                Ok(content) => Ok(ReadResourceResult {
+                    contents: vec![ResourceContents::TextResourceContents {
+                        uri: request.uri,
+                        mime_type: None,
+                        text: content,
+                    }],
+                }),
+                Err(e) => Err(Error::internal_error(e.to_string(), None)),
+            },
+        )
+    }
+
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo {
+            capabilities: ServerCapabilities::builder()
+                .enable_tools()
+                .enable_resources()
+                .build(),
+            instructions: Some(
+                "Help user to do what normally they can do using golem cli".to_string(),
+            ),
+            protocol_version: ProtocolVersion::V_2025_03_26,
+            server_info: Implementation {
+                name: "Golem Cli Mcp Server".to_string(),
+                version: "0.1.0".to_string(),
+            },
+        }
+    }
+}

--- a/golem-cli/src/command_handler/mcp_server/handler.rs
+++ b/golem-cli/src/command_handler/mcp_server/handler.rs
@@ -2,9 +2,7 @@ use std::{fs, future::Future, path::Path };
 
 use rmcp::{
     model::{
-        Implementation, ListResourcesResult, PaginatedRequestParam, ProtocolVersion, RawResource,
-        ReadResourceRequestParam, ReadResourceResult, Resource, ResourceContents,
-        ServerCapabilities, ServerInfo,
+        Implementation, ListResourcesResult, ListToolsResult, PaginatedRequestParam, ProtocolVersion, RawResource, ReadResourceRequestParam, ReadResourceResult, Resource, ResourceContents, ServerCapabilities, ServerInfo
     },
     service::RequestContext,
     tool_handler, Error, RoleServer, ServerHandler,
@@ -14,6 +12,7 @@ use crate::command_handler::mcp_server::GolemCliMcpServer;
 
 #[tool_handler]
 impl ServerHandler for GolemCliMcpServer {
+
     fn list_resources(
         &self,
         _request: Option<PaginatedRequestParam>,
@@ -110,7 +109,18 @@ impl ServerHandler for GolemCliMcpServer {
                 .enable_resources()
                 .build(),
             instructions: Some(
-                "Help user to perform what normally they can directly do using golem cli".to_string(),
+                "Tools Introduction
+                Helps interacting with Golem. It allows users to upload their components, launch new workers based on these components and call functions on running workers, etc..,
+
+                Call list_golem_mcp_server_tools once to know detailed info about available tools.
+
+                User uses these tools when using gemini cli or calude code or similar tools inside the golem app.
+                
+                📎 NOTES:
+                    - User requests should be interpreted and mapped internally to tool calls.
+                    - AI agents must ensure the `params` object includes all required keys and correct types.
+                    - No interactive shell exists. Every action is an atomic tool invocation.
+                ".to_string(),
             ),
             protocol_version: ProtocolVersion::V_2025_03_26,
             server_info: Implementation {

--- a/golem-cli/src/command_handler/mcp_server/handler.rs
+++ b/golem-cli/src/command_handler/mcp_server/handler.rs
@@ -90,7 +90,6 @@ impl ServerHandler for GolemCliMcpServer {
         _context: RequestContext<RoleServer>,
     ) -> impl Future<Output = Result<ReadResourceResult, Error>> + Send + '_ {
         std::future::ready(
-            // read file from request.uri path and send as content
             match fs::read_to_string(Path::new(&request.uri)) {
                 Ok(content) => Ok(ReadResourceResult {
                     contents: vec![ResourceContents::TextResourceContents {
@@ -111,7 +110,7 @@ impl ServerHandler for GolemCliMcpServer {
                 .enable_resources()
                 .build(),
             instructions: Some(
-                "Help user to do what normally they can do using golem cli".to_string(),
+                "Help user to perform what normally they can directly do using golem cli".to_string(),
             ),
             protocol_version: ProtocolVersion::V_2025_03_26,
             server_info: Implementation {

--- a/golem-cli/src/command_handler/mcp_server/mod.rs
+++ b/golem-cli/src/command_handler/mcp_server/mod.rs
@@ -1,0 +1,122 @@
+use std::{sync::Arc, time::Duration};
+
+use crate::{
+    command::mcp_server::{McpServerSubcommand, Transport},
+    context::Context,
+};
+
+use rmcp::{
+    handler::server::tool::ToolRouter,
+    transport::{SseServer, StreamableHttpServerConfig},
+};
+
+use hyper_util::{
+    rt::{TokioExecutor, TokioIo},
+    server::conn::auto::Builder,
+    service::TowerToHyperService,
+};
+use rmcp::transport::streamable_http_server::{
+    session::local::LocalSessionManager, StreamableHttpService,
+};
+
+mod handler;
+mod tools;
+
+pub struct McpServerCommandHandler {
+    _ctx: Arc<Context>,
+}
+
+impl McpServerCommandHandler {
+    pub fn new(ctx: Arc<Context>) -> Self {
+        Self { _ctx: ctx }
+    }
+
+    pub async fn handle_command(&self, subcommand: McpServerSubcommand) -> anyhow::Result<()> {
+        match subcommand {
+            McpServerSubcommand::Run {
+                port,
+                timeout,
+                transport,
+            } => self.mcp_server_start(port, timeout, transport).await,
+        }
+    }
+
+    async fn mcp_server_start(
+        &self,
+        port: Option<u16>,
+        timeout: Option<u64>,
+        transport: Option<Transport>,
+    ) -> anyhow::Result<()> {
+        let port = port.unwrap_or(8080);
+        let timeout = timeout.unwrap_or(6);
+
+        let transport_to_use = transport.unwrap_or(Transport::Sse);
+
+        match transport_to_use {
+            Transport::StreamableHttp => {
+                let service = TowerToHyperService::new(StreamableHttpService::new(
+                    || Ok(GolemCliMcpServer::new()),
+                    LocalSessionManager::default().into(),
+                    StreamableHttpServerConfig {
+                        sse_keep_alive: Some(Duration::new(timeout, 0)),
+                        ..Default::default()
+                    },
+                ));
+                let listener = tokio::net::TcpListener::bind(format!("[::1]:{}", port)).await?;
+                loop {
+                    let io = tokio::select! {
+                        _ = tokio::signal::ctrl_c() => break,
+                        accept = listener.accept() => {
+                            TokioIo::new(accept?.0)
+                        }
+                    };
+                    let service = service.clone();
+                    tokio::spawn(async move {
+                        let _result = Builder::new(TokioExecutor::default())
+                            .serve_connection(io, service)
+                            .await;
+                    });
+                }
+            }
+            Transport::Sse => {
+                let ct = SseServer::serve(format!("127.0.0.1:{}", port).parse()?)
+                    .await?
+                    .with_service_directly(GolemCliMcpServer::new);
+
+                tokio::signal::ctrl_c().await?;
+                ct.cancel();
+            }
+        }
+        Ok(())
+    }
+}
+
+pub struct GolemCliMcpServer {
+    tool_router: ToolRouter<GolemCliMcpServer>,
+}
+
+impl GolemCliMcpServer {
+    fn new() -> Self {
+        Self {
+            tool_router: self::GolemCliMcpServer::tool_router_app()
+                + self::GolemCliMcpServer::tool_router_component()
+                + self::GolemCliMcpServer::tool_router_component_plugin()
+                + self::GolemCliMcpServer::tool_router_api()
+                + self::GolemCliMcpServer::tool_router_api_definition()
+                + self::GolemCliMcpServer::tool_router_api_deployment()
+                // + self::GolemCliMcpServer::tool_router_api_security_scheme()
+                // + self::GolemCliMcpServer::tool_router_api_cloud_certificate()
+                + self::GolemCliMcpServer::tool_router_api_cloud_domain()
+                + self::GolemCliMcpServer::tool_router_cloud_account()
+                + self::GolemCliMcpServer::tool_router_cloud_account_grant()
+                + self::GolemCliMcpServer::tool_router_cloud_project_plugin()
+                + self::GolemCliMcpServer::tool_router_cloud_project_policy()
+                // + self::GolemCliMcpServer::tool_router_cloud_token()
+                + self::GolemCliMcpServer::tool_router_plugin()
+                + self::GolemCliMcpServer::tool_router_profile()
+                + self::GolemCliMcpServer::tool_router_profile_config()
+                + self::GolemCliMcpServer::tool_router_worker()
+                + self::GolemCliMcpServer::tool_router_repl(),
+        }
+    }
+}

--- a/golem-cli/src/command_handler/mcp_server/mod.rs
+++ b/golem-cli/src/command_handler/mcp_server/mod.rs
@@ -50,10 +50,12 @@ impl McpServerCommandHandler {
         let port = port.unwrap_or(8080);
         let timeout = timeout.unwrap_or(6);
 
-        let transport_to_use = transport.unwrap_or(Transport::Sse);
+        let transport_to_use = transport.unwrap_or_default();
 
         match transport_to_use {
             Transport::StreamableHttp => {
+                println!("Runing golem-cli mcp mode (StreamableHttp transport) on port {port}");
+
                 let service = TowerToHyperService::new(StreamableHttpService::new(
                     || Ok(GolemCliMcpServer::new()),
                     LocalSessionManager::default().into(),
@@ -79,6 +81,8 @@ impl McpServerCommandHandler {
                 }
             }
             Transport::Sse => {
+                println!("Runing golem-cli mcp mode (sse transport) on port {port}");
+
                 let ct = SseServer::serve(format!("127.0.0.1:{}", port).parse()?)
                     .await?
                     .with_service_directly(GolemCliMcpServer::new);

--- a/golem-cli/src/command_handler/mcp_server/mod.rs
+++ b/golem-cli/src/command_handler/mcp_server/mod.rs
@@ -120,7 +120,9 @@ impl GolemCliMcpServer {
                 + self::GolemCliMcpServer::tool_router_profile()
                 + self::GolemCliMcpServer::tool_router_profile_config()
                 + self::GolemCliMcpServer::tool_router_worker()
-                + self::GolemCliMcpServer::tool_router_repl(),
+                + self::GolemCliMcpServer::tool_router_repl()
+
+                + self::GolemCliMcpServer::tool_router_list_tools(),      
         }
     }
 }

--- a/golem-cli/src/command_handler/mcp_server/tools/api/cloud/certificate.rs
+++ b/golem-cli/src/command_handler/mcp_server/tools/api/cloud/certificate.rs
@@ -1,0 +1,187 @@
+use crate::command::shared_args::ProjectArg;
+use crate::command::GolemCliGlobalFlags;
+use crate::command_handler::api::cloud::certificate::ApiCloudCertificateCommandHandler;
+use crate::command_handler::mcp_server::GolemCliMcpServer;
+use crate::log::{McpClient, Output};
+use crate::model::PathBufOrStdin;
+use console::strip_ansi_codes;
+use rmcp::handler::server::tool::Parameters;
+use rmcp::model::{CallToolResult, Content};
+use rmcp::{schemars, tool, Error as CallToolError, Peer, RoleServer};
+use serde::{Deserialize, Serialize};
+use std::future::Future;
+use std::sync::Arc;
+use uuid::Uuid;
+
+/// Retrieves metadata about an existing certificate
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct Get {
+    project: ProjectArg,
+    /// Certificate ID
+    #[schemars(with = "String")]
+    certificate_id: Option<Uuid>,
+}
+
+/// Create new certificate
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct New {
+    project: ProjectArg,
+    /// Domain name
+    domain_name: String,
+    /// Certificate
+    certificate_body: PathBufOrStdin,
+    /// Certificate private key
+    certificate_private_key: PathBufOrStdin,
+}
+
+/// Delete an existing certificate
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct Delete {
+    project: ProjectArg,
+    /// Certificate ID
+    #[schemars(with = "String")]
+    certificate_id: Uuid,
+}
+
+// #[tool_router(router= tool_router_api_cloud_certificate, vis="pub")] // disabled
+impl GolemCliMcpServer {
+    #[tool(
+        name = "get_certificate",
+        description = "Retrieves metadata about an existing certificate"
+    )]
+    pub async fn get_certificate(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<Get>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "get_certificate".to_owned(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = ApiCloudCertificateCommandHandler::new(ctx.into());
+                match command_new
+                    .cmd_get(req.project.project, req.certificate_id)
+                    .await
+                {
+                    Ok(_) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+
+                        is_error: None,
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+
+    #[tool(
+        name = "delete_certificate",
+        description = "Delete an existing certificate"
+    )]
+    pub async fn delete_certificate(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<Delete>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "delete_certificate".to_owned(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = ApiCloudCertificateCommandHandler::new(ctx.into());
+                match command_new
+                    .cmd_delete(req.project.project, req.certificate_id)
+                    .await
+                {
+                    Ok(_) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+
+                        is_error: None,
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+
+    #[tool(name = "add_new_certificate", description = "Create new certificate")]
+    pub async fn add_new_certificate(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<New>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "add_new_Certificate".to_owned(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = ApiCloudCertificateCommandHandler::new(ctx.into());
+                match command_new
+                    .cmd_new(
+                        req.project.project,
+                        req.domain_name,
+                        req.certificate_body,
+                        req.certificate_private_key,
+                    )
+                    .await
+                {
+                    Ok(_) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+
+                        is_error: None,
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+}

--- a/golem-cli/src/command_handler/mcp_server/tools/api/cloud/certificate.rs
+++ b/golem-cli/src/command_handler/mcp_server/tools/api/cloud/certificate.rs
@@ -2,11 +2,11 @@ use crate::command::shared_args::ProjectArg;
 use crate::command::GolemCliGlobalFlags;
 use crate::command_handler::api::cloud::certificate::ApiCloudCertificateCommandHandler;
 use crate::command_handler::mcp_server::GolemCliMcpServer;
-use crate::log::{McpClient, Output};
+use crate::log::{Mcp, Output};
 use crate::model::PathBufOrStdin;
 use console::strip_ansi_codes;
 use rmcp::handler::server::tool::Parameters;
-use rmcp::model::{CallToolResult, Content};
+use rmcp::model::{CallToolResult, Content, Meta};
 use rmcp::{schemars, tool, Error as CallToolError, Peer, RoleServer};
 use serde::{Deserialize, Serialize};
 use std::future::Future;
@@ -51,6 +51,7 @@ impl GolemCliMcpServer {
     )]
     pub async fn get_certificate(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<Get>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -58,9 +59,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "get_certificate".to_owned(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -97,6 +99,7 @@ impl GolemCliMcpServer {
     )]
     pub async fn delete_certificate(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<Delete>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -104,9 +107,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "delete_certificate".to_owned(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -140,6 +144,7 @@ impl GolemCliMcpServer {
     #[tool(name = "add_new_certificate", description = "Create new certificate")]
     pub async fn add_new_certificate(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<New>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -147,9 +152,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "add_new_Certificate".to_owned(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server

--- a/golem-cli/src/command_handler/mcp_server/tools/api/cloud/certificate.rs
+++ b/golem-cli/src/command_handler/mcp_server/tools/api/cloud/certificate.rs
@@ -2,7 +2,7 @@ use crate::command::shared_args::ProjectArg;
 use crate::command::GolemCliGlobalFlags;
 use crate::command_handler::api::cloud::certificate::ApiCloudCertificateCommandHandler;
 use crate::command_handler::mcp_server::GolemCliMcpServer;
-use crate::log::{Mcp, Output};
+use crate::log::{get_mcp_tool_output, Mcp, Output};
 use crate::model::PathBufOrStdin;
 use console::strip_ansi_codes;
 use rmcp::handler::server::tool::Parameters;
@@ -62,7 +62,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "get_certificate".to_owned(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -76,7 +76,7 @@ impl GolemCliMcpServer {
                     .await
                 {
                     Ok(_) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
 
                         is_error: None,
                     }),
@@ -110,7 +110,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "delete_certificate".to_owned(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -124,7 +124,7 @@ impl GolemCliMcpServer {
                     .await
                 {
                     Ok(_) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
 
                         is_error: None,
                     }),
@@ -155,7 +155,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "add_new_Certificate".to_owned(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -174,7 +174,7 @@ impl GolemCliMcpServer {
                     .await
                 {
                     Ok(_) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
 
                         is_error: None,
                     }),

--- a/golem-cli/src/command_handler/mcp_server/tools/api/cloud/domain.rs
+++ b/golem-cli/src/command_handler/mcp_server/tools/api/cloud/domain.rs
@@ -2,10 +2,10 @@ use crate::command::shared_args::ProjectArg;
 use crate::command::GolemCliGlobalFlags;
 use crate::command_handler::api::cloud::domain::ApiCloudDomainCommandHandler;
 use crate::command_handler::mcp_server::GolemCliMcpServer;
-use crate::log::{McpClient, Output};
+use crate::log::{Mcp, Output};
 use console::strip_ansi_codes;
 use rmcp::handler::server::tool::Parameters;
-use rmcp::model::{CallToolResult, Content};
+use rmcp::model::{CallToolResult, Content, Meta};
 use rmcp::{schemars, tool, tool_router, Error as CallToolError, Peer, RoleServer};
 use serde::{Deserialize, Serialize};
 use std::future::Future;
@@ -41,6 +41,7 @@ impl GolemCliMcpServer {
     )]
     pub async fn get_domain(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<Get>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -48,9 +49,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "get_domain".to_owned(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -81,6 +83,7 @@ impl GolemCliMcpServer {
     #[tool(name = "delete_domain", description = "Delete an existing domain")]
     pub async fn delete_domain(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<Delete>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -88,9 +91,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "delete_domain".to_owned(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -124,6 +128,7 @@ impl GolemCliMcpServer {
     #[tool(name = "add_new_domain", description = "Add new domain")]
     pub async fn add_new_domain(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<New>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -131,9 +136,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "add_new_domain".to_owned(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server

--- a/golem-cli/src/command_handler/mcp_server/tools/api/cloud/domain.rs
+++ b/golem-cli/src/command_handler/mcp_server/tools/api/cloud/domain.rs
@@ -2,7 +2,7 @@ use crate::command::shared_args::ProjectArg;
 use crate::command::GolemCliGlobalFlags;
 use crate::command_handler::api::cloud::domain::ApiCloudDomainCommandHandler;
 use crate::command_handler::mcp_server::GolemCliMcpServer;
-use crate::log::{Mcp, Output};
+use crate::log::{get_mcp_tool_output, Mcp, Output};
 use console::strip_ansi_codes;
 use rmcp::handler::server::tool::Parameters;
 use rmcp::model::{CallToolResult, Content, Meta};
@@ -52,7 +52,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "get_domain".to_owned(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -63,7 +63,7 @@ impl GolemCliMcpServer {
                 let command_new = ApiCloudDomainCommandHandler::new(ctx.into());
                 match command_new.cmd_get(req.project.project).await {
                     Ok(_) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
 
                         is_error: None,
                     }),
@@ -94,7 +94,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "delete_domain".to_owned(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -108,7 +108,7 @@ impl GolemCliMcpServer {
                     .await
                 {
                     Ok(_) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
 
                         is_error: None,
                     }),
@@ -139,7 +139,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "add_new_domain".to_owned(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -153,7 +153,7 @@ impl GolemCliMcpServer {
                     .await
                 {
                     Ok(_) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
 
                         is_error: None,
                     }),

--- a/golem-cli/src/command_handler/mcp_server/tools/api/cloud/domain.rs
+++ b/golem-cli/src/command_handler/mcp_server/tools/api/cloud/domain.rs
@@ -1,0 +1,166 @@
+use crate::command::shared_args::ProjectArg;
+use crate::command::GolemCliGlobalFlags;
+use crate::command_handler::api::cloud::domain::ApiCloudDomainCommandHandler;
+use crate::command_handler::mcp_server::GolemCliMcpServer;
+use crate::log::{McpClient, Output};
+use console::strip_ansi_codes;
+use rmcp::handler::server::tool::Parameters;
+use rmcp::model::{CallToolResult, Content};
+use rmcp::{schemars, tool, tool_router, Error as CallToolError, Peer, RoleServer};
+use serde::{Deserialize, Serialize};
+use std::future::Future;
+use std::sync::Arc;
+
+/// Retrieves metadata about an existing domain
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct Get {
+    project: ProjectArg,
+}
+
+/// Add new domain
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct New {
+    project: ProjectArg,
+    /// Domain name
+    domain_name: String,
+}
+
+/// Delete an existing domain
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct Delete {
+    project: ProjectArg,
+    /// Domain name
+    domain_name: String,
+}
+
+#[tool_router(router= tool_router_api_cloud_domain, vis="pub")]
+impl GolemCliMcpServer {
+    #[tool(
+        name = "get_domain",
+        description = "Retrieves metadata about an existing domain"
+    )]
+    pub async fn get_domain(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<Get>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "get_domain".to_owned(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = ApiCloudDomainCommandHandler::new(ctx.into());
+                match command_new.cmd_get(req.project.project).await {
+                    Ok(_) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+
+                        is_error: None,
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+
+    #[tool(name = "delete_domain", description = "Delete an existing domain")]
+    pub async fn delete_domain(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<Delete>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "delete_domain".to_owned(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = ApiCloudDomainCommandHandler::new(ctx.into());
+                match command_new
+                    .cmd_delete(req.project.project, req.domain_name)
+                    .await
+                {
+                    Ok(_) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+
+                        is_error: None,
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+
+    #[tool(name = "add_new_domain", description = "Add new domain")]
+    pub async fn add_new_domain(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<New>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "add_new_domain".to_owned(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = ApiCloudDomainCommandHandler::new(ctx.into());
+                match command_new
+                    .cmd_new(req.project.project, req.domain_name)
+                    .await
+                {
+                    Ok(_) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+
+                        is_error: None,
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+}

--- a/golem-cli/src/command_handler/mcp_server/tools/api/cloud/mod.rs
+++ b/golem-cli/src/command_handler/mcp_server/tools/api/cloud/mod.rs
@@ -1,0 +1,2 @@
+pub mod certificate;
+pub mod domain;

--- a/golem-cli/src/command_handler/mcp_server/tools/api/definition.rs
+++ b/golem-cli/src/command_handler/mcp_server/tools/api/definition.rs
@@ -2,12 +2,12 @@ use crate::command::shared_args::{ProjectOptionalFlagArg, UpdateOrRedeployArgs};
 use crate::command::GolemCliGlobalFlags;
 use crate::command_handler::api::definition::ApiDefinitionCommandHandler;
 use crate::command_handler::mcp_server::GolemCliMcpServer;
-use crate::log::{McpClient, Output};
+use crate::log::{Mcp, Output};
 use crate::model::api::{ApiDefinitionId, ApiDefinitionVersion};
 use crate::model::app::HttpApiDefinitionName;
 use console::strip_ansi_codes;
 use rmcp::handler::server::tool::Parameters;
-use rmcp::model::{CallToolResult, Content};
+use rmcp::model::{CallToolResult, Content, Meta};
 use rmcp::{schemars, tool, tool_router, Error as CallToolError, Peer, RoleServer};
 use serde::{Deserialize, Serialize};
 use std::future::Future;
@@ -57,6 +57,7 @@ impl GolemCliMcpServer {
     )]
     pub async fn get_api_definition(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<Get>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -64,9 +65,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "get_api_definition".to_owned(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -100,6 +102,7 @@ impl GolemCliMcpServer {
     )]
     pub async fn list_api_definitions(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<List>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -107,9 +110,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "list_api_definitions".to_owned(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -143,6 +147,7 @@ impl GolemCliMcpServer {
     )]
     pub async fn delete_api_definition(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<Delete>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -150,9 +155,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "delete_api_definition".to_owned(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -189,6 +195,7 @@ impl GolemCliMcpServer {
     )]
     pub async fn deploy_api_definitions(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<Deploy>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -196,9 +203,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "deploy_api_definitions".to_owned(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server

--- a/golem-cli/src/command_handler/mcp_server/tools/api/definition.rs
+++ b/golem-cli/src/command_handler/mcp_server/tools/api/definition.rs
@@ -2,7 +2,7 @@ use crate::command::shared_args::{ProjectOptionalFlagArg, UpdateOrRedeployArgs};
 use crate::command::GolemCliGlobalFlags;
 use crate::command_handler::api::definition::ApiDefinitionCommandHandler;
 use crate::command_handler::mcp_server::GolemCliMcpServer;
-use crate::log::{Mcp, Output};
+use crate::log::{get_mcp_tool_output, Mcp, Output};
 use crate::model::api::{ApiDefinitionId, ApiDefinitionVersion};
 use crate::model::app::HttpApiDefinitionName;
 use console::strip_ansi_codes;
@@ -68,7 +68,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "get_api_definition".to_owned(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -79,7 +79,7 @@ impl GolemCliMcpServer {
                 let command_new = ApiDefinitionCommandHandler::new(ctx.into());
                 match command_new.cmd_get(req.project, req.id, req.version).await {
                     Ok(_) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
 
                         is_error: None,
                     }),
@@ -113,7 +113,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "list_api_definitions".to_owned(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -124,7 +124,7 @@ impl GolemCliMcpServer {
                 let command_new = ApiDefinitionCommandHandler::new(ctx.into());
                 match command_new.cmd_list(req.project, req.id).await {
                     Ok(_) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
 
                         is_error: None,
                     }),
@@ -158,7 +158,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "delete_api_definition".to_owned(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -172,7 +172,7 @@ impl GolemCliMcpServer {
                     .await
                 {
                     Ok(_) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
 
                         is_error: None,
                     }),
@@ -206,7 +206,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "deploy_api_definitions".to_owned(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -226,7 +226,7 @@ impl GolemCliMcpServer {
                 .await
                 {
                     Ok(_) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
 
                         is_error: None,
                     }),

--- a/golem-cli/src/command_handler/mcp_server/tools/api/definition.rs
+++ b/golem-cli/src/command_handler/mcp_server/tools/api/definition.rs
@@ -1,0 +1,237 @@
+use crate::command::shared_args::{ProjectOptionalFlagArg, UpdateOrRedeployArgs};
+use crate::command::GolemCliGlobalFlags;
+use crate::command_handler::api::definition::ApiDefinitionCommandHandler;
+use crate::command_handler::mcp_server::GolemCliMcpServer;
+use crate::log::{McpClient, Output};
+use crate::model::api::{ApiDefinitionId, ApiDefinitionVersion};
+use crate::model::app::HttpApiDefinitionName;
+use console::strip_ansi_codes;
+use rmcp::handler::server::tool::Parameters;
+use rmcp::model::{CallToolResult, Content};
+use rmcp::{schemars, tool, tool_router, Error as CallToolError, Peer, RoleServer};
+use serde::{Deserialize, Serialize};
+use std::future::Future;
+use std::sync::Arc;
+
+/// Deploy API Definitions and required components
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct Deploy {
+    /// API definition to deploy, if not specified, all definitions are deployed
+    http_api_definition_name: Option<HttpApiDefinitionName>,
+    update_or_redeploy: UpdateOrRedeployArgs,
+}
+
+/// Retrieves metadata about an existing API definition
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct Get {
+    project: ProjectOptionalFlagArg,
+    /// API definition id
+    id: ApiDefinitionId,
+    /// Version of the api definition
+    version: ApiDefinitionVersion,
+}
+
+/// Lists all API definitions
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct List {
+    project: ProjectOptionalFlagArg,
+    /// API definition id to get all versions. Optional.
+    id: Option<ApiDefinitionId>,
+}
+
+/// Deletes an existing API definition
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct Delete {
+    project: ProjectOptionalFlagArg,
+    /// API definition id
+    id: ApiDefinitionId,
+    /// Version of the api definition
+    version: ApiDefinitionVersion,
+}
+
+#[tool_router(router= tool_router_api_definition, vis="pub")]
+impl GolemCliMcpServer {
+    #[tool(
+        name = "get_api_definition",
+        description = "Retrieves metadata about an existing API definition"
+    )]
+    pub async fn get_api_definition(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<Get>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "get_api_definition".to_owned(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = ApiDefinitionCommandHandler::new(ctx.into());
+                match command_new.cmd_get(req.project, req.id, req.version).await {
+                    Ok(_) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+
+                        is_error: None,
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+
+    #[tool(
+        name = "list_api_definitions",
+        description = "Lists all API definitions"
+    )]
+    pub async fn list_api_definitions(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<List>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "list_api_definitions".to_owned(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = ApiDefinitionCommandHandler::new(ctx.into());
+                match command_new.cmd_list(req.project, req.id).await {
+                    Ok(_) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+
+                        is_error: None,
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+
+    #[tool(
+        name = "delete_api_definition",
+        description = "Delete an existing API definition"
+    )]
+    pub async fn delete_api_definition(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<Delete>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "delete_api_definition".to_owned(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = ApiDefinitionCommandHandler::new(ctx.into());
+                match command_new
+                    .cmd_delete(req.project, req.id, req.version)
+                    .await
+                {
+                    Ok(_) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+
+                        is_error: None,
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+
+    #[tool(
+        name = "deploy_api_definitions",
+        description = "Deploy API Definitions and required components"
+    )]
+    pub async fn deploy_api_definitions(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<Deploy>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "deploy_api_definitions".to_owned(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = ApiDefinitionCommandHandler::new(ctx.into());
+                match tokio::task::spawn_blocking(move || {
+                    let rt = tokio::runtime::Runtime::new().unwrap();
+                    rt.block_on(async {
+                        command_new
+                            .cmd_deploy(req.http_api_definition_name, req.update_or_redeploy)
+                            .await
+                    })
+                })
+                .await
+                {
+                    Ok(_) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+
+                        is_error: None,
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+}

--- a/golem-cli/src/command_handler/mcp_server/tools/api/deployment.rs
+++ b/golem-cli/src/command_handler/mcp_server/tools/api/deployment.rs
@@ -2,7 +2,7 @@ use crate::command::shared_args::{ProjectOptionalFlagArg, UpdateOrRedeployArgs};
 use crate::command::GolemCliGlobalFlags;
 use crate::command_handler::api::deployment::ApiDeploymentCommandHandler;
 use crate::command_handler::mcp_server::GolemCliMcpServer;
-use crate::log::{Mcp, Output};
+use crate::log::{get_mcp_tool_output, Mcp, Output};
 use crate::model::api::ApiDefinitionId;
 use console::strip_ansi_codes;
 use rmcp::handler::server::tool::Parameters;
@@ -63,7 +63,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "get_api_deployment".to_owned(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -74,7 +74,7 @@ impl GolemCliMcpServer {
                 let command_new = ApiDeploymentCommandHandler::new(ctx.into());
                 match command_new.cmd_get(req.project, req.site).await {
                     Ok(_) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
 
                         is_error: None,
                     }),
@@ -108,7 +108,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "list_api_deployment".to_owned(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -119,7 +119,7 @@ impl GolemCliMcpServer {
                 let command_new = ApiDeploymentCommandHandler::new(ctx.into());
                 match command_new.cmd_list(req.project, req.definition).await {
                     Ok(_) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
 
                         is_error: None,
                     }),
@@ -150,7 +150,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "delete_api_deployment".to_owned(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -161,7 +161,7 @@ impl GolemCliMcpServer {
                 let command_new = ApiDeploymentCommandHandler::new(ctx.into());
                 match command_new.cmd_delete(req.project, req.site).await {
                     Ok(_) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
 
                         is_error: None,
                     }),
@@ -195,7 +195,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "deploy_api_deployments".to_owned(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -215,7 +215,7 @@ impl GolemCliMcpServer {
                 .await
                 {
                     Ok(_) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
 
                         is_error: None,
                     }),

--- a/golem-cli/src/command_handler/mcp_server/tools/api/deployment.rs
+++ b/golem-cli/src/command_handler/mcp_server/tools/api/deployment.rs
@@ -1,0 +1,226 @@
+use crate::command::shared_args::{ProjectOptionalFlagArg, UpdateOrRedeployArgs};
+use crate::command::GolemCliGlobalFlags;
+use crate::command_handler::api::deployment::ApiDeploymentCommandHandler;
+use crate::command_handler::mcp_server::GolemCliMcpServer;
+use crate::log::{McpClient, Output};
+use crate::model::api::ApiDefinitionId;
+use console::strip_ansi_codes;
+use rmcp::handler::server::tool::Parameters;
+use rmcp::model::{CallToolResult, Content};
+use rmcp::{schemars, tool, tool_router, Error as CallToolError, Peer, RoleServer};
+use serde::{Deserialize, Serialize};
+use std::future::Future;
+use std::sync::Arc;
+
+/// Deploy API Deployments
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct Deploy {
+    /// Host or site to deploy, if not defined, all deployments will be deployed
+    host_or_site: Option<String>,
+    update_or_redeploy: UpdateOrRedeployArgs,
+}
+
+/// Get API deployment
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct Get {
+    project: ProjectOptionalFlagArg,
+    /// Deployment site
+    site: String,
+}
+
+/// List API deployment for API definition
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct List {
+    project: ProjectOptionalFlagArg,
+    /// API definition id
+    definition: Option<ApiDefinitionId>,
+}
+
+/// Delete api deployment
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct Delete {
+    project: ProjectOptionalFlagArg,
+    /// Deployment site
+    site: String,
+}
+
+#[tool_router(router= tool_router_api_deployment, vis="pub")]
+impl GolemCliMcpServer {
+    #[tool(
+        name = "get_api_deployment",
+        description = "Retrieves metadata about an existing API deployment"
+    )]
+    pub async fn get_api_deployment(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<Get>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "get_api_deployment".to_owned(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = ApiDeploymentCommandHandler::new(ctx.into());
+                match command_new.cmd_get(req.project, req.site).await {
+                    Ok(_) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+
+                        is_error: None,
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+
+    #[tool(
+        name = "list_api_deployment",
+        description = "List API deployment for API definition"
+    )]
+    pub async fn list_api_deployment(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<List>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "list_api_deployment".to_owned(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = ApiDeploymentCommandHandler::new(ctx.into());
+                match command_new.cmd_list(req.project, req.definition).await {
+                    Ok(_) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+
+                        is_error: None,
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+
+    #[tool(name = "delete_api_deployment", description = "Delete api deployment")]
+    pub async fn delete_api_deployment(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<Delete>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "delete_api_deployment".to_owned(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = ApiDeploymentCommandHandler::new(ctx.into());
+                match command_new.cmd_delete(req.project, req.site).await {
+                    Ok(_) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+
+                        is_error: None,
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+
+    #[tool(
+        name = "deploy_api_deployments",
+        description = "Deploy API Deployments"
+    )]
+    pub async fn deploy_api_deployments(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<Deploy>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "deploy_api_deployments".to_owned(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = ApiDeploymentCommandHandler::new(ctx.into());
+                match tokio::task::spawn_blocking(move || {
+                    let rt = tokio::runtime::Runtime::new().unwrap();
+                    rt.block_on(async {
+                        command_new
+                            .cmd_deploy(req.host_or_site, req.update_or_redeploy)
+                            .await
+                    })
+                })
+                .await
+                {
+                    Ok(_) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+
+                        is_error: None,
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+}

--- a/golem-cli/src/command_handler/mcp_server/tools/api/deployment.rs
+++ b/golem-cli/src/command_handler/mcp_server/tools/api/deployment.rs
@@ -2,11 +2,11 @@ use crate::command::shared_args::{ProjectOptionalFlagArg, UpdateOrRedeployArgs};
 use crate::command::GolemCliGlobalFlags;
 use crate::command_handler::api::deployment::ApiDeploymentCommandHandler;
 use crate::command_handler::mcp_server::GolemCliMcpServer;
-use crate::log::{McpClient, Output};
+use crate::log::{Mcp, Output};
 use crate::model::api::ApiDefinitionId;
 use console::strip_ansi_codes;
 use rmcp::handler::server::tool::Parameters;
-use rmcp::model::{CallToolResult, Content};
+use rmcp::model::{CallToolResult, Content, Meta};
 use rmcp::{schemars, tool, tool_router, Error as CallToolError, Peer, RoleServer};
 use serde::{Deserialize, Serialize};
 use std::future::Future;
@@ -52,6 +52,7 @@ impl GolemCliMcpServer {
     )]
     pub async fn get_api_deployment(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<Get>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -59,9 +60,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "get_api_deployment".to_owned(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -95,6 +97,7 @@ impl GolemCliMcpServer {
     )]
     pub async fn list_api_deployment(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<List>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -102,9 +105,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "list_api_deployment".to_owned(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -135,6 +139,7 @@ impl GolemCliMcpServer {
     #[tool(name = "delete_api_deployment", description = "Delete api deployment")]
     pub async fn delete_api_deployment(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<Delete>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -142,9 +147,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "delete_api_deployment".to_owned(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -178,6 +184,7 @@ impl GolemCliMcpServer {
     )]
     pub async fn deploy_api_deployments(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<Deploy>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -185,9 +192,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "deploy_api_deployments".to_owned(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server

--- a/golem-cli/src/command_handler/mcp_server/tools/api/mod.rs
+++ b/golem-cli/src/command_handler/mcp_server/tools/api/mod.rs
@@ -1,0 +1,74 @@
+use crate::command::shared_args::UpdateOrRedeployArgs;
+use crate::command::GolemCliGlobalFlags;
+use crate::command_handler::api::ApiCommandHandler;
+use crate::command_handler::mcp_server::GolemCliMcpServer;
+use crate::log::{McpClient, Output};
+use console::strip_ansi_codes;
+use rmcp::handler::server::tool::Parameters;
+use rmcp::model::{CallToolResult, Content};
+use rmcp::{schemars, tool, tool_router, Error as CallToolError, Peer, RoleServer};
+use serde::{Deserialize, Serialize};
+use std::future::Future;
+use std::sync::Arc;
+
+pub mod cloud;
+pub mod definition;
+pub mod deployment;
+pub mod security_scheme;
+
+/// Deploy API Definitions and Deployments
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct Deploy {
+    update_or_redeploy: UpdateOrRedeployArgs,
+}
+
+#[tool_router(router= tool_router_api, vis="pub")]
+impl GolemCliMcpServer {
+    #[tool(
+        name = "deploy_api_definitions_and_deployments",
+        description = "Deploy API Definitions and Deployments"
+    )]
+    pub async fn deploy_api_definitions_and_deployments(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<Deploy>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "deploy_api_definitions_and_deployments".to_owned(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = ApiCommandHandler::new(ctx.into());
+                match tokio::task::spawn_blocking(move || {
+                    let rt = tokio::runtime::Runtime::new().unwrap();
+                    rt.block_on(async { command_new.cmd_deploy(req.update_or_redeploy).await })
+                })
+                .await
+                {
+                    Ok(_) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+
+                        is_error: None,
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+}

--- a/golem-cli/src/command_handler/mcp_server/tools/api/mod.rs
+++ b/golem-cli/src/command_handler/mcp_server/tools/api/mod.rs
@@ -2,7 +2,7 @@ use crate::command::shared_args::UpdateOrRedeployArgs;
 use crate::command::GolemCliGlobalFlags;
 use crate::command_handler::api::ApiCommandHandler;
 use crate::command_handler::mcp_server::GolemCliMcpServer;
-use crate::log::{Mcp, Output};
+use crate::log::{get_mcp_tool_output, Mcp, Output};
 use console::strip_ansi_codes;
 use rmcp::handler::server::tool::Parameters;
 use rmcp::model::{CallToolResult, Content, Meta};
@@ -41,7 +41,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "deploy_api_definitions_and_deployments".to_owned(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -57,7 +57,7 @@ impl GolemCliMcpServer {
                 .await
                 {
                     Ok(_) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
 
                         is_error: None,
                     }),

--- a/golem-cli/src/command_handler/mcp_server/tools/api/mod.rs
+++ b/golem-cli/src/command_handler/mcp_server/tools/api/mod.rs
@@ -2,10 +2,10 @@ use crate::command::shared_args::UpdateOrRedeployArgs;
 use crate::command::GolemCliGlobalFlags;
 use crate::command_handler::api::ApiCommandHandler;
 use crate::command_handler::mcp_server::GolemCliMcpServer;
-use crate::log::{McpClient, Output};
+use crate::log::{Mcp, Output};
 use console::strip_ansi_codes;
 use rmcp::handler::server::tool::Parameters;
-use rmcp::model::{CallToolResult, Content};
+use rmcp::model::{CallToolResult, Content, Meta};
 use rmcp::{schemars, tool, tool_router, Error as CallToolError, Peer, RoleServer};
 use serde::{Deserialize, Serialize};
 use std::future::Future;
@@ -30,6 +30,7 @@ impl GolemCliMcpServer {
     )]
     pub async fn deploy_api_definitions_and_deployments(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<Deploy>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -37,9 +38,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "deploy_api_definitions_and_deployments".to_owned(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server

--- a/golem-cli/src/command_handler/mcp_server/tools/api/security_scheme.rs
+++ b/golem-cli/src/command_handler/mcp_server/tools/api/security_scheme.rs
@@ -2,7 +2,7 @@ use crate::command::shared_args::ProjectOptionalFlagArg;
 use crate::command::GolemCliGlobalFlags;
 use crate::command_handler::api::security_scheme::ApiSecuritySchemeCommandHandler;
 use crate::command_handler::mcp_server::GolemCliMcpServer;
-use crate::log::{Mcp, Output};
+use crate::log::{get_mcp_tool_output, Mcp, Output};
 use crate::model::api::IdentityProviderType;
 use console::strip_ansi_codes;
 use rmcp::handler::server::tool::Parameters;
@@ -54,7 +54,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "get_api_security_scheme".to_owned(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -68,7 +68,7 @@ impl GolemCliMcpServer {
                     .await
                 {
                     Ok(_) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
 
                         is_error: None,
                     }),
@@ -102,7 +102,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "create_api_security_scheme".to_owned(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -124,7 +124,7 @@ impl GolemCliMcpServer {
                     .await
                 {
                     Ok(_) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
 
                         is_error: None,
                     }),

--- a/golem-cli/src/command_handler/mcp_server/tools/api/security_scheme.rs
+++ b/golem-cli/src/command_handler/mcp_server/tools/api/security_scheme.rs
@@ -1,0 +1,139 @@
+use crate::command::shared_args::ProjectOptionalFlagArg;
+use crate::command::GolemCliGlobalFlags;
+use crate::command_handler::api::security_scheme::ApiSecuritySchemeCommandHandler;
+use crate::command_handler::mcp_server::GolemCliMcpServer;
+use crate::log::{McpClient, Output};
+use crate::model::api::IdentityProviderType;
+use console::strip_ansi_codes;
+use rmcp::handler::server::tool::Parameters;
+use rmcp::model::{CallToolResult, Content};
+use rmcp::{schemars, tool, Error as CallToolError, Peer, RoleServer};
+use serde::{Deserialize, Serialize};
+use std::future::Future;
+use std::sync::Arc;
+
+/// Create API Security Scheme
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct Create {
+    project: ProjectOptionalFlagArg,
+    /// Security Scheme ID
+    security_scheme_id: String,
+    /// Security Scheme provider (Google, Facebook, Gitlab, Microsoft)
+    provider_type: IdentityProviderType,
+    /// Security Scheme client ID
+    client_id: String,
+    /// Security Scheme client secret
+    client_secret: String,
+    /// Security Scheme Scopes, can be defined multiple times
+    scope: Vec<String>,
+    /// Security Scheme redirect URL
+    redirect_url: String,
+}
+
+/// Get API security
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct Get {
+    project: ProjectOptionalFlagArg,
+    /// Security Scheme ID
+    security_scheme_id: String,
+}
+
+// #[tool_router(router= tool_router_api_security_scheme, vis="pub")] // disabled
+impl GolemCliMcpServer {
+    #[tool(name = "get_api_security_scheme", description = "Get API security")]
+    pub async fn get_api_security_scheme(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<Get>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "get_api_security_scheme".to_owned(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = ApiSecuritySchemeCommandHandler::new(ctx.into());
+                match command_new
+                    .cmd_get(req.project, req.security_scheme_id)
+                    .await
+                {
+                    Ok(_) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+
+                        is_error: None,
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+
+    #[tool(
+        name = "create_api_security_scheme",
+        description = "Create API Security Scheme"
+    )]
+    pub async fn create_api_security_scheme(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<Create>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "create_api_security_scheme".to_owned(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = ApiSecuritySchemeCommandHandler::new(ctx.into());
+                match command_new
+                    .cmd_create(
+                        req.project,
+                        req.security_scheme_id,
+                        req.provider_type,
+                        req.client_id,
+                        req.client_secret,
+                        req.scope,
+                        req.redirect_url,
+                    )
+                    .await
+                {
+                    Ok(_) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+
+                        is_error: None,
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+}

--- a/golem-cli/src/command_handler/mcp_server/tools/api/security_scheme.rs
+++ b/golem-cli/src/command_handler/mcp_server/tools/api/security_scheme.rs
@@ -2,11 +2,11 @@ use crate::command::shared_args::ProjectOptionalFlagArg;
 use crate::command::GolemCliGlobalFlags;
 use crate::command_handler::api::security_scheme::ApiSecuritySchemeCommandHandler;
 use crate::command_handler::mcp_server::GolemCliMcpServer;
-use crate::log::{McpClient, Output};
+use crate::log::{Mcp, Output};
 use crate::model::api::IdentityProviderType;
 use console::strip_ansi_codes;
 use rmcp::handler::server::tool::Parameters;
-use rmcp::model::{CallToolResult, Content};
+use rmcp::model::{CallToolResult, Content, Meta};
 use rmcp::{schemars, tool, Error as CallToolError, Peer, RoleServer};
 use serde::{Deserialize, Serialize};
 use std::future::Future;
@@ -43,6 +43,7 @@ impl GolemCliMcpServer {
     #[tool(name = "get_api_security_scheme", description = "Get API security")]
     pub async fn get_api_security_scheme(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<Get>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -50,9 +51,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "get_api_security_scheme".to_owned(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -89,6 +91,7 @@ impl GolemCliMcpServer {
     )]
     pub async fn create_api_security_scheme(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<Create>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -96,9 +99,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "create_api_security_scheme".to_owned(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server

--- a/golem-cli/src/command_handler/mcp_server/tools/app.rs
+++ b/golem-cli/src/command_handler/mcp_server/tools/app.rs
@@ -4,12 +4,12 @@ use crate::command::shared_args::{
 use crate::command::GolemCliGlobalFlags;
 use crate::command_handler::app::AppCommandHandler;
 use crate::command_handler::mcp_server::GolemCliMcpServer;
-use crate::log::{McpClient, Output};
+use crate::log::{Mcp, Output};
 use crate::model::WorkerUpdateMode;
 use console::strip_ansi_codes;
 use golem_templates::model::{GuestLanguage, default_guest_language};
 use rmcp::handler::server::tool::Parameters;
-use rmcp::model::{CallToolResult, Content};
+use rmcp::model::{CallToolResult, Content, Meta};
 use rmcp::{schemars, tool, tool_router, Error as CallToolError, Peer, RoleServer};
 use serde::{Deserialize, Serialize};
 use std::future::Future;
@@ -77,6 +77,7 @@ impl GolemCliMcpServer {
     #[tool(name = "create_new_app", description = "Create a new golem app")]
     pub async fn create_new_app(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<New>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -84,9 +85,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "create_new_app".to_owned(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -120,6 +122,7 @@ impl GolemCliMcpServer {
     #[tool(name = "custom_command", description = "Custom command in a golem app")]
     pub async fn custom_command(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<CustomCommand>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -127,9 +130,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "custom_command".to_owned(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -160,6 +164,7 @@ impl GolemCliMcpServer {
     #[tool(name = "update_app_workers", description = "Update app workers")]
     pub async fn update_app_workers(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<UpdateWorkers>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -167,9 +172,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "update_app_workers".to_owned(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
@@ -202,6 +208,7 @@ impl GolemCliMcpServer {
     #[tool(name = "redeploy_app_workers", description = "Redeploy app workers")]
     pub async fn redeploy_app_workers(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<RedeployWorkers>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -209,9 +216,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "redeploy_app_workers".to_owned(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
@@ -244,6 +252,7 @@ impl GolemCliMcpServer {
     #[tool(name = "build_app", description = "Build app")]
     pub async fn build_app(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<Build>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -251,9 +260,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "build_app".to_owned(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
@@ -294,6 +304,7 @@ impl GolemCliMcpServer {
     #[tool(name = "deploy_app", description = "Deploy app")]
     pub async fn deploy_app(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<Deploy>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -301,9 +312,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "deploy_app".to_owned(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
@@ -346,6 +358,7 @@ impl GolemCliMcpServer {
     #[tool(name = "clean_app", description = "Clean app")]
     pub async fn clean_app(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<Clean>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -353,9 +366,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "clean_app".to_owned(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
@@ -386,6 +400,7 @@ impl GolemCliMcpServer {
     #[tool(name = "diagnose_app", description = "Diagnose app")]
     pub async fn diagnose_app(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<Diagnose>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -393,9 +408,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "diagnose_app".to_string(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now

--- a/golem-cli/src/command_handler/mcp_server/tools/app.rs
+++ b/golem-cli/src/command_handler/mcp_server/tools/app.rs
@@ -4,7 +4,7 @@ use crate::command::shared_args::{
 use crate::command::GolemCliGlobalFlags;
 use crate::command_handler::app::AppCommandHandler;
 use crate::command_handler::mcp_server::GolemCliMcpServer;
-use crate::log::{Mcp, Output};
+use crate::log::{get_mcp_tool_output, Mcp, Output};
 use crate::model::WorkerUpdateMode;
 use console::strip_ansi_codes;
 use golem_templates::model::{GuestLanguage, default_guest_language};
@@ -88,7 +88,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "create_new_app".to_owned(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -102,7 +102,7 @@ impl GolemCliMcpServer {
                     .await
                 {
                     Ok(_) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
 
                         is_error: None,
                     }),
@@ -133,7 +133,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "custom_command".to_owned(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -144,7 +144,7 @@ impl GolemCliMcpServer {
                 let command_new = AppCommandHandler::new(ctx.into());
                 match command_new.cmd_custom_command(req.command).await {
                     Ok(_) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
 
                         is_error: None,
                     }),
@@ -175,7 +175,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "update_app_workers".to_owned(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
@@ -189,7 +189,7 @@ impl GolemCliMcpServer {
                     .await
                 {
                     Ok(_) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
                         is_error: None,
                     }),
                     Err(e) => Ok(CallToolResult {
@@ -219,7 +219,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "redeploy_app_workers".to_owned(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
@@ -233,7 +233,7 @@ impl GolemCliMcpServer {
                     .await
                 {
                     Ok(_) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
                         is_error: None,
                     }),
                     Err(e) => Ok(CallToolResult {
@@ -263,7 +263,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "build_app".to_owned(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
@@ -281,7 +281,7 @@ impl GolemCliMcpServer {
                 .await
                 {
                     Ok(Ok(_)) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
                         is_error: None,
                     }),
                     Ok(Err(e)) => Ok(CallToolResult {
@@ -315,7 +315,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "deploy_app".to_owned(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
@@ -335,7 +335,7 @@ impl GolemCliMcpServer {
                 .await
                 {
                     Ok(Ok(_)) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
                         is_error: None,
                     }),
                     Ok(Err(e)) => Ok(CallToolResult {
@@ -369,7 +369,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "clean_app".to_owned(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
@@ -381,7 +381,7 @@ impl GolemCliMcpServer {
 
                 match command_new.cmd_clean(req.component_name).await {
                     Ok(_) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
                         is_error: None,
                     }),
                     Err(e) => Ok(CallToolResult {
@@ -411,7 +411,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "diagnose_app".to_string(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
@@ -423,7 +423,7 @@ impl GolemCliMcpServer {
 
                 match command_new.cmd_diagnose(req.component_name).await {
                     Ok(_) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
                         is_error: None,
                     }),
                     Err(e) => Ok(CallToolResult {

--- a/golem-cli/src/command_handler/mcp_server/tools/app.rs
+++ b/golem-cli/src/command_handler/mcp_server/tools/app.rs
@@ -68,7 +68,9 @@ pub struct Diagnose {
 
 /// Run custom command
 #[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
-pub struct CustomCommand(Vec<String>);
+pub struct CustomCommand{
+    command: Vec<String>
+}
 
 #[tool_router(router= tool_router_app, vis="pub")]
 impl GolemCliMcpServer {
@@ -136,7 +138,7 @@ impl GolemCliMcpServer {
         {
             Ok(ctx) => {
                 let command_new = AppCommandHandler::new(ctx.into());
-                match command_new.cmd_custom_command(req.0).await {
+                match command_new.cmd_custom_command(req.command).await {
                     Ok(_) => Ok(CallToolResult {
                         content: vec![Content::text("Success")],
 

--- a/golem-cli/src/command_handler/mcp_server/tools/app.rs
+++ b/golem-cli/src/command_handler/mcp_server/tools/app.rs
@@ -1,0 +1,423 @@
+use crate::command::shared_args::{
+    AppOptionalComponentNames, BuildArgs, ForceBuildArg, UpdateOrRedeployArgs,
+};
+use crate::command::GolemCliGlobalFlags;
+use crate::command_handler::app::AppCommandHandler;
+use crate::command_handler::mcp_server::GolemCliMcpServer;
+use crate::log::{McpClient, Output};
+use crate::model::WorkerUpdateMode;
+use console::strip_ansi_codes;
+use golem_templates::model::{GuestLanguage, default_guest_language};
+use rmcp::handler::server::tool::Parameters;
+use rmcp::model::{CallToolResult, Content};
+use rmcp::{schemars, tool, tool_router, Error as CallToolError, Peer, RoleServer};
+use serde::{Deserialize, Serialize};
+use std::future::Future;
+use std::sync::Arc;
+
+/// Create new application
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct New {
+    /// Application folder name where the new application should be created
+    application_name: String,
+    /// Languages that the application should support, default langauge : rust
+    #[schemars(default="default_guest_language")]
+    language: Vec<GuestLanguage>,
+}
+
+/// Build all or selected components in the application
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct Build {
+    component_name: AppOptionalComponentNames,
+    build: BuildArgs,
+}
+
+/// Deploy all or selected components and HTTP APIs in the application, includes building
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct Deploy {
+    component_name: AppOptionalComponentNames,
+    force_build: ForceBuildArg,
+    update_or_redeploy: UpdateOrRedeployArgs,
+}
+
+/// Clean all components in the application or by selection
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct Clean {
+    component_name: AppOptionalComponentNames,
+}
+
+/// Try to automatically update all existing workers of the application to the latest version
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct UpdateWorkers {
+    component_name: AppOptionalComponentNames,
+    /// Update mode - auto or manual, defaults to "auto"
+    update_mode: WorkerUpdateMode,
+}
+
+/// Redeploy all workers of the application using the latest version
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct RedeployWorkers {
+    component_name: AppOptionalComponentNames,
+}
+
+/// Diagnose possible tooling problems
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct Diagnose {
+    component_name: AppOptionalComponentNames,
+}
+
+/// Run custom command
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct CustomCommand(Vec<String>);
+
+#[tool_router(router= tool_router_app, vis="pub")]
+impl GolemCliMcpServer {
+    #[tool(name = "create_new_app", description = "Create a new golem app")]
+    pub async fn create_new_app(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<New>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "create_new_app".to_owned(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = AppCommandHandler::new(ctx.into());
+                match command_new
+                    .cmd_new(Some(req.application_name), req.language)
+                    .await
+                {
+                    Ok(_) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+
+                        is_error: None,
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+
+    #[tool(name = "custom_command", description = "Custom command in a golem app")]
+    pub async fn custom_command(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<CustomCommand>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "custom_command".to_owned(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = AppCommandHandler::new(ctx.into());
+                match command_new.cmd_custom_command(req.0).await {
+                    Ok(_) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+
+                        is_error: None,
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+
+    #[tool(name = "update_app_workers", description = "Update app workers")]
+    pub async fn update_app_workers(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<UpdateWorkers>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "update_app_workers".to_owned(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = AppCommandHandler::new(ctx.into());
+                match command_new
+                    .cmd_update_workers(req.component_name.component_name, req.update_mode)
+                    .await
+                {
+                    Ok(_) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+                        is_error: None,
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+
+    #[tool(name = "redeploy_app_workers", description = "Redeploy app workers")]
+    pub async fn redeploy_app_workers(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<RedeployWorkers>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "redeploy_app_workers".to_owned(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = AppCommandHandler::new(ctx.into());
+                match command_new
+                    .cmd_redeploy_workers(req.component_name.component_name)
+                    .await
+                {
+                    Ok(_) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+                        is_error: None,
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+
+    #[tool(name = "build_app", description = "Build app")]
+    pub async fn build_app(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<Build>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "build_app".to_owned(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = AppCommandHandler::new(ctx.into());
+                match tokio::task::spawn_blocking(move || {
+                    let rt = tokio::runtime::Runtime::new().unwrap();
+                    rt.block_on(async {
+                        command_new.cmd_build(req.component_name, req.build).await
+                    })
+                })
+                .await
+                {
+                    Ok(Ok(_)) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+                        is_error: None,
+                    }),
+                    Ok(Err(e)) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+
+    #[tool(name = "deploy_app", description = "Deploy app")]
+    pub async fn deploy_app(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<Deploy>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "deploy_app".to_owned(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = AppCommandHandler::new(ctx.into());
+                match tokio::task::spawn_blocking(move || {
+                    let rt = tokio::runtime::Runtime::new().unwrap();
+                    rt.block_on(async {
+                        command_new
+                            .cmd_deploy(req.component_name, req.force_build, req.update_or_redeploy)
+                            .await
+                    })
+                })
+                .await
+                {
+                    Ok(Ok(_)) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+                        is_error: None,
+                    }),
+                    Ok(Err(e)) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+
+    #[tool(name = "clean_app", description = "Clean app")]
+    pub async fn clean_app(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<Clean>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "clean_app".to_owned(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = AppCommandHandler::new(ctx.into());
+
+                match command_new.cmd_clean(req.component_name).await {
+                    Ok(_) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+                        is_error: None,
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+
+    #[tool(name = "diagnose_app", description = "Diagnose app")]
+    pub async fn diagnose_app(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<Diagnose>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "diagnose_app".to_string(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = AppCommandHandler::new(ctx.into());
+
+                match command_new.cmd_diagnose(req.component_name).await {
+                    Ok(_) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+                        is_error: None,
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+}

--- a/golem-cli/src/command_handler/mcp_server/tools/cloud/account/grant.rs
+++ b/golem-cli/src/command_handler/mcp_server/tools/cloud/account/grant.rs
@@ -2,11 +2,11 @@ use crate::command::shared_args::AccountIdOptionalArg;
 use crate::command::GolemCliGlobalFlags;
 use crate::command_handler::cloud::account::grant::CloudAccountGrantCommandHandler;
 use crate::command_handler::mcp_server::GolemCliMcpServer;
-use crate::log::{McpClient, Output};
+use crate::log::{Mcp, Output};
 use crate::model::Role;
 use console::strip_ansi_codes;
 use rmcp::handler::server::tool::Parameters;
-use rmcp::model::{CallToolResult, Content};
+use rmcp::model::{CallToolResult, Content, Meta};
 use rmcp::{schemars, tool, tool_router, Error as CallToolError, Peer, RoleServer};
 use serde::{Deserialize, Serialize};
 use std::future::Future;
@@ -42,6 +42,7 @@ impl GolemCliMcpServer {
     )]
     pub async fn create_new_cloud_account_grant(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<New>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -49,9 +50,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "create_new_cloud_account_grant".to_owned(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -88,6 +90,7 @@ impl GolemCliMcpServer {
     )]
     pub async fn get_cloud_account_grant_roles(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<Get>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -95,9 +98,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "get_cloud_account_grant_roles".to_owned(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -131,6 +135,7 @@ impl GolemCliMcpServer {
     )]
     pub async fn delete_cloud_account_grant_role(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<Delete>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -138,9 +143,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "delete_cloud_account_grant_role".to_owned(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server

--- a/golem-cli/src/command_handler/mcp_server/tools/cloud/account/grant.rs
+++ b/golem-cli/src/command_handler/mcp_server/tools/cloud/account/grant.rs
@@ -1,0 +1,173 @@
+use crate::command::shared_args::AccountIdOptionalArg;
+use crate::command::GolemCliGlobalFlags;
+use crate::command_handler::cloud::account::grant::CloudAccountGrantCommandHandler;
+use crate::command_handler::mcp_server::GolemCliMcpServer;
+use crate::log::{McpClient, Output};
+use crate::model::Role;
+use console::strip_ansi_codes;
+use rmcp::handler::server::tool::Parameters;
+use rmcp::model::{CallToolResult, Content};
+use rmcp::{schemars, tool, tool_router, Error as CallToolError, Peer, RoleServer};
+use serde::{Deserialize, Serialize};
+use std::future::Future;
+use std::sync::Arc;
+
+/// Get the roles granted to the account
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct Get {
+    account_id: AccountIdOptionalArg,
+}
+
+/// Grant a new role to the account
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct New {
+    account_id: AccountIdOptionalArg,
+    /// The role to be granted
+    role: Role,
+}
+
+/// Remove a role from the account
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct Delete {
+    account_id: AccountIdOptionalArg,
+    /// The role to be deleted
+    role: Role,
+}
+
+#[tool_router(router= tool_router_cloud_account_grant, vis="pub")]
+impl GolemCliMcpServer {
+    #[tool(
+        name = "create_new_cloud_account_grant",
+        description = "Grant a new role to the account"
+    )]
+    pub async fn create_new_cloud_account_grant(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<New>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "create_new_cloud_account_grant".to_owned(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = CloudAccountGrantCommandHandler::new(ctx.into());
+                match command_new
+                    .cmd_new(req.account_id.account_id, req.role)
+                    .await
+                {
+                    Ok(_) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+
+                        is_error: None,
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+
+    #[tool(
+        name = "get_cloud_account_grant_roles",
+        description = "Get the roles granted to the account"
+    )]
+    pub async fn get_cloud_account_grant_roles(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<Get>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "get_cloud_account_grant_roles".to_owned(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = CloudAccountGrantCommandHandler::new(ctx.into());
+                match command_new.cmd_get(req.account_id.account_id).await {
+                    Ok(_) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+
+                        is_error: None,
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+
+    #[tool(
+        name = "delete_cloud_account_grant_role",
+        description = "Remove a role from the account"
+    )]
+    pub async fn delete_cloud_account_grant_role(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<Delete>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "delete_cloud_account_grant_role".to_owned(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = CloudAccountGrantCommandHandler::new(ctx.into());
+                match command_new
+                    .cmd_delete(req.account_id.account_id, req.role)
+                    .await
+                {
+                    Ok(_) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+
+                        is_error: None,
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+}

--- a/golem-cli/src/command_handler/mcp_server/tools/cloud/account/grant.rs
+++ b/golem-cli/src/command_handler/mcp_server/tools/cloud/account/grant.rs
@@ -2,7 +2,7 @@ use crate::command::shared_args::AccountIdOptionalArg;
 use crate::command::GolemCliGlobalFlags;
 use crate::command_handler::cloud::account::grant::CloudAccountGrantCommandHandler;
 use crate::command_handler::mcp_server::GolemCliMcpServer;
-use crate::log::{Mcp, Output};
+use crate::log::{get_mcp_tool_output, Mcp, Output};
 use crate::model::Role;
 use console::strip_ansi_codes;
 use rmcp::handler::server::tool::Parameters;
@@ -53,7 +53,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "create_new_cloud_account_grant".to_owned(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -67,7 +67,7 @@ impl GolemCliMcpServer {
                     .await
                 {
                     Ok(_) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
 
                         is_error: None,
                     }),
@@ -101,7 +101,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "get_cloud_account_grant_roles".to_owned(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -112,7 +112,7 @@ impl GolemCliMcpServer {
                 let command_new = CloudAccountGrantCommandHandler::new(ctx.into());
                 match command_new.cmd_get(req.account_id.account_id).await {
                     Ok(_) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
 
                         is_error: None,
                     }),
@@ -146,7 +146,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "delete_cloud_account_grant_role".to_owned(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -160,7 +160,7 @@ impl GolemCliMcpServer {
                     .await
                 {
                     Ok(_) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
 
                         is_error: None,
                     }),

--- a/golem-cli/src/command_handler/mcp_server/tools/cloud/account/mod.rs
+++ b/golem-cli/src/command_handler/mcp_server/tools/cloud/account/mod.rs
@@ -2,10 +2,10 @@ use crate::command::shared_args::AccountIdOptionalArg;
 use crate::command::GolemCliGlobalFlags;
 use crate::command_handler::cloud::account::CloudAccountCommandHandler;
 use crate::command_handler::mcp_server::GolemCliMcpServer;
-use crate::log::{McpClient, Output};
+use crate::log::{Mcp, Output};
 use console::strip_ansi_codes;
 use rmcp::handler::server::tool::Parameters;
-use rmcp::model::{CallToolResult, Content};
+use rmcp::model::{CallToolResult, Content, Meta};
 use rmcp::{schemars, tool, tool_router, Error as CallToolError, Peer, RoleServer};
 use serde::{Deserialize, Serialize};
 use std::future::Future;
@@ -49,6 +49,7 @@ impl GolemCliMcpServer {
     #[tool(name = "create_new_cloud_account", description = "Add a new account")]
     pub async fn create_new_cloud_account(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<New>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -56,9 +57,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "create_new_cloud_account".to_owned(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -95,6 +97,7 @@ impl GolemCliMcpServer {
     )]
     pub async fn get_cloud_account(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<Get>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -102,9 +105,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "get_cloud_account".to_owned(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -138,6 +142,7 @@ impl GolemCliMcpServer {
     )]
     pub async fn update_cloud_account(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<Update>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -145,9 +150,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "update_cloud_account".to_owned(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -185,6 +191,7 @@ impl GolemCliMcpServer {
     #[tool(name = "delete_cloud_account", description = "Delete the account")]
     pub async fn delete_cloud_account(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<Delete>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -192,9 +199,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "delete_cloud_account".to_owned(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server

--- a/golem-cli/src/command_handler/mcp_server/tools/cloud/account/mod.rs
+++ b/golem-cli/src/command_handler/mcp_server/tools/cloud/account/mod.rs
@@ -1,0 +1,224 @@
+use crate::command::shared_args::AccountIdOptionalArg;
+use crate::command::GolemCliGlobalFlags;
+use crate::command_handler::cloud::account::CloudAccountCommandHandler;
+use crate::command_handler::mcp_server::GolemCliMcpServer;
+use crate::log::{McpClient, Output};
+use console::strip_ansi_codes;
+use rmcp::handler::server::tool::Parameters;
+use rmcp::model::{CallToolResult, Content};
+use rmcp::{schemars, tool, tool_router, Error as CallToolError, Peer, RoleServer};
+use serde::{Deserialize, Serialize};
+use std::future::Future;
+use std::sync::Arc;
+
+pub mod grant;
+
+/// Get information about the account
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct Get {
+    account_id: AccountIdOptionalArg,
+}
+
+/// Update some information about the account
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct Update {
+    account_id: AccountIdOptionalArg,
+    /// Set the account's name
+    account_name: Option<String>,
+    /// Set the account's email address
+    account_email: Option<String>,
+}
+
+/// Add a new account
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct New {
+    /// The new account's name
+    account_name: String,
+    /// The new account's email address
+    account_email: String,
+}
+
+/// Delete the account
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct Delete {
+    account_id: AccountIdOptionalArg,
+}
+
+#[tool_router(router= tool_router_cloud_account, vis="pub")]
+impl GolemCliMcpServer {
+    #[tool(name = "create_new_cloud_account", description = "Add a new account")]
+    pub async fn create_new_cloud_account(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<New>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "create_new_cloud_account".to_owned(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = CloudAccountCommandHandler::new(ctx.into());
+                match command_new
+                    .cmd_new(req.account_name, req.account_email)
+                    .await
+                {
+                    Ok(_) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+
+                        is_error: None,
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+
+    #[tool(
+        name = "get_cloud_account",
+        description = "Get information about the account"
+    )]
+    pub async fn get_cloud_account(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<Get>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "get_cloud_account".to_owned(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = CloudAccountCommandHandler::new(ctx.into());
+                match command_new.cmd_get(req.account_id.account_id).await {
+                    Ok(_) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+
+                        is_error: None,
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+
+    #[tool(
+        name = "update_cloud_account",
+        description = "Update some information about the account"
+    )]
+    pub async fn update_cloud_account(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<Update>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "update_cloud_account".to_owned(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = CloudAccountCommandHandler::new(ctx.into());
+                match command_new
+                    .cmd_update(
+                        req.account_id.account_id,
+                        req.account_name,
+                        req.account_email,
+                    )
+                    .await
+                {
+                    Ok(_) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+
+                        is_error: None,
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+
+    #[tool(name = "delete_cloud_account", description = "Delete the account")]
+    pub async fn delete_cloud_account(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<Delete>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "delete_cloud_account".to_owned(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = CloudAccountCommandHandler::new(ctx.into());
+                match command_new.cmd_delete(req.account_id.account_id).await {
+                    Ok(_) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+
+                        is_error: None,
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+}

--- a/golem-cli/src/command_handler/mcp_server/tools/cloud/account/mod.rs
+++ b/golem-cli/src/command_handler/mcp_server/tools/cloud/account/mod.rs
@@ -2,7 +2,7 @@ use crate::command::shared_args::AccountIdOptionalArg;
 use crate::command::GolemCliGlobalFlags;
 use crate::command_handler::cloud::account::CloudAccountCommandHandler;
 use crate::command_handler::mcp_server::GolemCliMcpServer;
-use crate::log::{Mcp, Output};
+use crate::log::{get_mcp_tool_output, Mcp, Output};
 use console::strip_ansi_codes;
 use rmcp::handler::server::tool::Parameters;
 use rmcp::model::{CallToolResult, Content, Meta};
@@ -60,7 +60,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "create_new_cloud_account".to_owned(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -74,7 +74,7 @@ impl GolemCliMcpServer {
                     .await
                 {
                     Ok(_) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
 
                         is_error: None,
                     }),
@@ -108,7 +108,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "get_cloud_account".to_owned(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -119,7 +119,7 @@ impl GolemCliMcpServer {
                 let command_new = CloudAccountCommandHandler::new(ctx.into());
                 match command_new.cmd_get(req.account_id.account_id).await {
                     Ok(_) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
 
                         is_error: None,
                     }),
@@ -153,7 +153,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "update_cloud_account".to_owned(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -171,7 +171,7 @@ impl GolemCliMcpServer {
                     .await
                 {
                     Ok(_) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
 
                         is_error: None,
                     }),
@@ -202,7 +202,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "delete_cloud_account".to_owned(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -213,7 +213,7 @@ impl GolemCliMcpServer {
                 let command_new = CloudAccountCommandHandler::new(ctx.into());
                 match command_new.cmd_delete(req.account_id.account_id).await {
                     Ok(_) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
 
                         is_error: None,
                     }),

--- a/golem-cli/src/command_handler/mcp_server/tools/cloud/mod.rs
+++ b/golem-cli/src/command_handler/mcp_server/tools/cloud/mod.rs
@@ -1,0 +1,3 @@
+pub mod account;
+pub mod project;
+pub mod token;

--- a/golem-cli/src/command_handler/mcp_server/tools/cloud/project/mod.rs
+++ b/golem-cli/src/command_handler/mcp_server/tools/cloud/project/mod.rs
@@ -1,0 +1,2 @@
+pub mod plugin;
+pub mod policy;

--- a/golem-cli/src/command_handler/mcp_server/tools/cloud/project/plugin.rs
+++ b/golem-cli/src/command_handler/mcp_server/tools/cloud/project/plugin.rs
@@ -2,11 +2,11 @@ use crate::command::shared_args::ProjectArg;
 use crate::command::GolemCliGlobalFlags;
 use crate::command_handler::cloud::project::plugin::CloudProjectPluginCommandHandler;
 use crate::command_handler::mcp_server::GolemCliMcpServer;
-use crate::log::{McpClient, Output};
+use crate::log::{Mcp, Output};
 use console::strip_ansi_codes;
 use golem_common::model::PluginInstallationId;
 use rmcp::handler::server::tool::Parameters;
-use rmcp::model::{CallToolResult, Content};
+use rmcp::model::{CallToolResult, Content, Meta};
 use rmcp::{schemars, tool, tool_router, Error as CallToolError, Peer, RoleServer};
 use serde::{Deserialize, Serialize};
 use std::future::Future;
@@ -66,6 +66,7 @@ impl GolemCliMcpServer {
     )]
     pub async fn install_project_plugin(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<Install>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -73,9 +74,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "install_project_plugin".to_owned(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -118,6 +120,7 @@ impl GolemCliMcpServer {
     )]
     pub async fn uninstall_project_plugin(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<Uninstall>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -125,9 +128,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "uninstall_project_plugin".to_owned(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -164,6 +168,7 @@ impl GolemCliMcpServer {
     )]
     pub async fn get_cloud_project_plugins(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<Get>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -171,9 +176,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "get_cloud_project_plugins".to_owned(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -204,6 +210,7 @@ impl GolemCliMcpServer {
     #[tool(name = "update_project_plugin", description = "Update project plugin")]
     pub async fn update_project_plugin(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<Update>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -211,9 +218,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "update_project_plugin".to_owned(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server

--- a/golem-cli/src/command_handler/mcp_server/tools/cloud/project/plugin.rs
+++ b/golem-cli/src/command_handler/mcp_server/tools/cloud/project/plugin.rs
@@ -2,7 +2,7 @@ use crate::command::shared_args::ProjectArg;
 use crate::command::GolemCliGlobalFlags;
 use crate::command_handler::cloud::project::plugin::CloudProjectPluginCommandHandler;
 use crate::command_handler::mcp_server::GolemCliMcpServer;
-use crate::log::{Mcp, Output};
+use crate::log::{get_mcp_tool_output, Mcp, Output};
 use console::strip_ansi_codes;
 use golem_common::model::PluginInstallationId;
 use rmcp::handler::server::tool::Parameters;
@@ -77,7 +77,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "install_project_plugin".to_owned(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -97,7 +97,7 @@ impl GolemCliMcpServer {
                     .await
                 {
                     Ok(_) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
 
                         is_error: None,
                     }),
@@ -131,7 +131,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "uninstall_project_plugin".to_owned(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -145,7 +145,7 @@ impl GolemCliMcpServer {
                     .await
                 {
                     Ok(_) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
 
                         is_error: None,
                     }),
@@ -179,7 +179,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "get_cloud_project_plugins".to_owned(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -190,7 +190,7 @@ impl GolemCliMcpServer {
                 let command_new = CloudProjectPluginCommandHandler::new(ctx.into());
                 match command_new.cmd_get(req.project.project).await {
                     Ok(_) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
 
                         is_error: None,
                     }),
@@ -221,7 +221,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "update_project_plugin".to_owned(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -240,7 +240,7 @@ impl GolemCliMcpServer {
                     .await
                 {
                     Ok(_) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
 
                         is_error: None,
                     }),

--- a/golem-cli/src/command_handler/mcp_server/tools/cloud/project/plugin.rs
+++ b/golem-cli/src/command_handler/mcp_server/tools/cloud/project/plugin.rs
@@ -1,0 +1,251 @@
+use crate::command::shared_args::ProjectArg;
+use crate::command::GolemCliGlobalFlags;
+use crate::command_handler::cloud::project::plugin::CloudProjectPluginCommandHandler;
+use crate::command_handler::mcp_server::GolemCliMcpServer;
+use crate::log::{McpClient, Output};
+use console::strip_ansi_codes;
+use golem_common::model::PluginInstallationId;
+use rmcp::handler::server::tool::Parameters;
+use rmcp::model::{CallToolResult, Content};
+use rmcp::{schemars, tool, tool_router, Error as CallToolError, Peer, RoleServer};
+use serde::{Deserialize, Serialize};
+use std::future::Future;
+use std::sync::Arc;
+
+/// Install a plugin for a project
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct Install {
+    project: ProjectArg,
+    /// The plugin to install
+    plugin_name: String,
+    /// The version of the plugin to install
+    plugin_version: String,
+    /// Priority of the plugin - largest priority is applied first
+    priority: i32,
+    /// List of parameters (key-value pairs) passed to the plugin
+    param: Vec<(String, String)>,
+}
+
+/// Get the installed plugins for the project
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct Get {
+    project: ProjectArg,
+    /* TODO: Missing from HTTP API
+    /// The version of the component
+    version: Option<u64>,
+    */
+}
+
+/// Update project plugin
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct Update {
+    project: ProjectArg,
+    /// Installation id of the plugin to update
+    #[schemars(with = "String")]
+    plugin_installation_id: PluginInstallationId,
+    /// Updated priority of the plugin - largest priority is applied first
+    priority: i32,
+    /// Updated list of parameters (key-value pairs) passed to the plugin
+    param: Vec<(String, String)>,
+}
+
+/// Uninstall a plugin for selected component
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct Uninstall {
+    project: ProjectArg,
+    /// Installation id of the plugin to uninstall
+    #[schemars(with = "String")]
+    plugin_installation_id: PluginInstallationId,
+}
+
+#[tool_router(router= tool_router_cloud_project_plugin, vis="pub")]
+impl GolemCliMcpServer {
+    #[tool(
+        name = "install_project_plugin",
+        description = "Install a plugin for a project"
+    )]
+    pub async fn install_project_plugin(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<Install>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "install_project_plugin".to_owned(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = CloudProjectPluginCommandHandler::new(ctx.into());
+                match command_new
+                    .cmd_install(
+                        req.project.project,
+                        req.plugin_name,
+                        req.plugin_version,
+                        req.priority,
+                        req.param,
+                    )
+                    .await
+                {
+                    Ok(_) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+
+                        is_error: None,
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+
+    #[tool(
+        name = "uninstall_project_plugin",
+        description = "Uninstall a plugin for selected component"
+    )]
+    pub async fn uninstall_project_plugin(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<Uninstall>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "uninstall_project_plugin".to_owned(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = CloudProjectPluginCommandHandler::new(ctx.into());
+                match command_new
+                    .cmd_uninstall(req.project.project, req.plugin_installation_id)
+                    .await
+                {
+                    Ok(_) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+
+                        is_error: None,
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+
+    #[tool(
+        name = "get_cloud_project_plugins",
+        description = "Get the installed plugins for the project"
+    )]
+    pub async fn get_cloud_project_plugins(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<Get>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "get_cloud_project_plugins".to_owned(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = CloudProjectPluginCommandHandler::new(ctx.into());
+                match command_new.cmd_get(req.project.project).await {
+                    Ok(_) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+
+                        is_error: None,
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+
+    #[tool(name = "update_project_plugin", description = "Update project plugin")]
+    pub async fn update_project_plugin(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<Update>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "update_project_plugin".to_owned(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = CloudProjectPluginCommandHandler::new(ctx.into());
+                match command_new
+                    .cmd_update(
+                        req.project.project,
+                        req.plugin_installation_id,
+                        req.priority,
+                        req.param,
+                    )
+                    .await
+                {
+                    Ok(_) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+
+                        is_error: None,
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+}

--- a/golem-cli/src/command_handler/mcp_server/tools/cloud/project/policy.rs
+++ b/golem-cli/src/command_handler/mcp_server/tools/cloud/project/policy.rs
@@ -1,0 +1,119 @@
+use crate::command::GolemCliGlobalFlags;
+use crate::command_handler::cloud::project::policy::CloudProjectPolicyCommandHandler;
+use crate::command_handler::mcp_server::GolemCliMcpServer;
+use crate::log::{McpClient, Output};
+use crate::model::ProjectPermission;
+use crate::model::ProjectPolicyId;
+use console::strip_ansi_codes;
+use rmcp::handler::server::tool::Parameters;
+use rmcp::model::{CallToolResult, Content};
+use rmcp::{schemars, tool, tool_router, Error as CallToolError, Peer, RoleServer};
+use serde::{Deserialize, Serialize};
+use std::future::Future;
+use std::sync::Arc;
+
+/// Creates a new project sharing policy
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct New {
+    /// Name of the policy
+    policy_name: String,
+    /// List of actions allowed by the policy
+    actions: Vec<ProjectPermission>,
+}
+
+/// Gets the existing project sharing policies
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct Get {
+    /// Project policy ID
+    #[schemars(with = "String")]
+    policy_id: ProjectPolicyId,
+}
+
+#[tool_router(router= tool_router_cloud_project_policy, vis="pub")]
+impl GolemCliMcpServer {
+    #[tool(
+        name = "create_new_project_policy",
+        description = "Creates a new project sharing policy"
+    )]
+    pub async fn create_new_project_policy(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<New>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "create_new_project_policy".to_owned(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = CloudProjectPolicyCommandHandler::new(ctx.into());
+                match command_new.cmd_new(req.policy_name, req.actions).await {
+                    Ok(_) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+
+                        is_error: None,
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+
+    #[tool(
+        name = "get_project_policies",
+        description = "Gets the existing project sharing policies"
+    )]
+    pub async fn get_project_policies(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<Get>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "get_project_policies".to_owned(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = CloudProjectPolicyCommandHandler::new(ctx.into());
+                match command_new.cmd_get(req.policy_id).await {
+                    Ok(_) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+
+                        is_error: None,
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+}

--- a/golem-cli/src/command_handler/mcp_server/tools/cloud/project/policy.rs
+++ b/golem-cli/src/command_handler/mcp_server/tools/cloud/project/policy.rs
@@ -1,7 +1,7 @@
 use crate::command::GolemCliGlobalFlags;
 use crate::command_handler::cloud::project::policy::CloudProjectPolicyCommandHandler;
 use crate::command_handler::mcp_server::GolemCliMcpServer;
-use crate::log::{Mcp, Output};
+use crate::log::{get_mcp_tool_output, Mcp, Output};
 use crate::model::ProjectPermission;
 use crate::model::ProjectPolicyId;
 use console::strip_ansi_codes;
@@ -48,7 +48,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "create_new_project_policy".to_owned(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -59,7 +59,7 @@ impl GolemCliMcpServer {
                 let command_new = CloudProjectPolicyCommandHandler::new(ctx.into());
                 match command_new.cmd_new(req.policy_name, req.actions).await {
                     Ok(_) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
 
                         is_error: None,
                     }),
@@ -93,7 +93,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "get_project_policies".to_owned(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -104,7 +104,7 @@ impl GolemCliMcpServer {
                 let command_new = CloudProjectPolicyCommandHandler::new(ctx.into());
                 match command_new.cmd_get(req.policy_id).await {
                     Ok(_) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
 
                         is_error: None,
                     }),

--- a/golem-cli/src/command_handler/mcp_server/tools/cloud/project/policy.rs
+++ b/golem-cli/src/command_handler/mcp_server/tools/cloud/project/policy.rs
@@ -1,12 +1,12 @@
 use crate::command::GolemCliGlobalFlags;
 use crate::command_handler::cloud::project::policy::CloudProjectPolicyCommandHandler;
 use crate::command_handler::mcp_server::GolemCliMcpServer;
-use crate::log::{McpClient, Output};
+use crate::log::{Mcp, Output};
 use crate::model::ProjectPermission;
 use crate::model::ProjectPolicyId;
 use console::strip_ansi_codes;
 use rmcp::handler::server::tool::Parameters;
-use rmcp::model::{CallToolResult, Content};
+use rmcp::model::{CallToolResult, Content, Meta};
 use rmcp::{schemars, tool, tool_router, Error as CallToolError, Peer, RoleServer};
 use serde::{Deserialize, Serialize};
 use std::future::Future;
@@ -37,6 +37,7 @@ impl GolemCliMcpServer {
     )]
     pub async fn create_new_project_policy(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<New>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -44,9 +45,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "create_new_project_policy".to_owned(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -80,6 +82,7 @@ impl GolemCliMcpServer {
     )]
     pub async fn get_project_policies(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<Get>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -87,9 +90,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "get_project_policies".to_owned(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server

--- a/golem-cli/src/command_handler/mcp_server/tools/cloud/token.rs
+++ b/golem-cli/src/command_handler/mcp_server/tools/cloud/token.rs
@@ -1,0 +1,155 @@
+use crate::command::GolemCliGlobalFlags;
+use crate::command_handler::cloud::token::CloudTokenCommandHandler;
+use crate::command_handler::mcp_server::GolemCliMcpServer;
+use crate::log::{McpClient, Output};
+use crate::model::TokenId;
+use chrono::{DateTime, Utc};
+use console::strip_ansi_codes;
+use rmcp::handler::server::tool::Parameters;
+use rmcp::model::{CallToolResult, Content};
+use rmcp::{schemars, tool, Error as CallToolError, Peer, RoleServer};
+use serde::{Deserialize, Serialize};
+use std::future::Future;
+use std::sync::Arc;
+
+/// List tokens
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct List {}
+
+/// Create new token
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct New {
+    /// Expiration date of the generated token
+    expires_at: DateTime<Utc>,
+}
+
+/// Delete an existing token
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct Delete {
+    /// Token ID
+    #[schemars(with = "String")]
+    token_id: TokenId,
+}
+
+// #[tool_router(router= tool_router_cloud_token, vis="pub")] // diable for mcp for now
+impl GolemCliMcpServer {
+    #[tool(name = "create_new_token", description = "Create new token")]
+    pub async fn create_new_token(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<New>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "create_new_token".to_owned(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = CloudTokenCommandHandler::new(ctx.into());
+                match command_new.cmd_new(req.expires_at).await {
+                    Ok(_) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+
+                        is_error: None,
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+
+    #[tool(name = "list_tokens", description = "List tokens")]
+    pub async fn list_tokens(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(_): Parameters<List>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "list_tokens".to_owned(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = CloudTokenCommandHandler::new(ctx.into());
+                match command_new.cmd_list().await {
+                    Ok(_) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+
+                        is_error: None,
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+
+    #[tool(name = "delete_tokens", description = "Delete an existing token")]
+    pub async fn delete_tokens(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<Delete>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "delete_tokens".to_owned(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = CloudTokenCommandHandler::new(ctx.into());
+                match command_new.cmd_delete(req.token_id).await {
+                    Ok(_) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+
+                        is_error: None,
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+}

--- a/golem-cli/src/command_handler/mcp_server/tools/cloud/token.rs
+++ b/golem-cli/src/command_handler/mcp_server/tools/cloud/token.rs
@@ -1,7 +1,7 @@
 use crate::command::GolemCliGlobalFlags;
 use crate::command_handler::cloud::token::CloudTokenCommandHandler;
 use crate::command_handler::mcp_server::GolemCliMcpServer;
-use crate::log::{Mcp, Output};
+use crate::log::{get_mcp_tool_output, Mcp, Output};
 use crate::model::TokenId;
 use chrono::{DateTime, Utc};
 use console::strip_ansi_codes;
@@ -47,7 +47,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "create_new_token".to_owned(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -58,7 +58,7 @@ impl GolemCliMcpServer {
                 let command_new = CloudTokenCommandHandler::new(ctx.into());
                 match command_new.cmd_new(req.expires_at).await {
                     Ok(_) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
 
                         is_error: None,
                     }),
@@ -89,7 +89,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "list_tokens".to_owned(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -100,7 +100,7 @@ impl GolemCliMcpServer {
                 let command_new = CloudTokenCommandHandler::new(ctx.into());
                 match command_new.cmd_list().await {
                     Ok(_) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
 
                         is_error: None,
                     }),
@@ -131,7 +131,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "delete_tokens".to_owned(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -142,7 +142,7 @@ impl GolemCliMcpServer {
                 let command_new = CloudTokenCommandHandler::new(ctx.into());
                 match command_new.cmd_delete(req.token_id).await {
                     Ok(_) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
 
                         is_error: None,
                     }),

--- a/golem-cli/src/command_handler/mcp_server/tools/cloud/token.rs
+++ b/golem-cli/src/command_handler/mcp_server/tools/cloud/token.rs
@@ -1,12 +1,12 @@
 use crate::command::GolemCliGlobalFlags;
 use crate::command_handler::cloud::token::CloudTokenCommandHandler;
 use crate::command_handler::mcp_server::GolemCliMcpServer;
-use crate::log::{McpClient, Output};
+use crate::log::{Mcp, Output};
 use crate::model::TokenId;
 use chrono::{DateTime, Utc};
 use console::strip_ansi_codes;
 use rmcp::handler::server::tool::Parameters;
-use rmcp::model::{CallToolResult, Content};
+use rmcp::model::{CallToolResult, Content, Meta};
 use rmcp::{schemars, tool, Error as CallToolError, Peer, RoleServer};
 use serde::{Deserialize, Serialize};
 use std::future::Future;
@@ -36,6 +36,7 @@ impl GolemCliMcpServer {
     #[tool(name = "create_new_token", description = "Create new token")]
     pub async fn create_new_token(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<New>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -43,9 +44,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "create_new_token".to_owned(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -76,6 +78,7 @@ impl GolemCliMcpServer {
     #[tool(name = "list_tokens", description = "List tokens")]
     pub async fn list_tokens(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(_): Parameters<List>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -83,9 +86,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "list_tokens".to_owned(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -116,6 +120,7 @@ impl GolemCliMcpServer {
     #[tool(name = "delete_tokens", description = "Delete an existing token")]
     pub async fn delete_tokens(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<Delete>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -123,9 +128,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "delete_tokens".to_owned(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server

--- a/golem-cli/src/command_handler/mcp_server/tools/component/mod.rs
+++ b/golem-cli/src/command_handler/mcp_server/tools/component/mod.rs
@@ -3,7 +3,7 @@ use crate::command::shared_args::{
     UpdateOrRedeployArgs,
 };
 use crate::command_handler::mcp_server::GolemCliMcpServer;
-use crate::log::{Mcp, Output};
+use crate::log::{get_mcp_tool_output, Mcp, Output};
 use crate::model::app::DependencyType;
 use crate::model::{ComponentName, WorkerUpdateMode };
 use crate::{command::GolemCliGlobalFlags, command_handler::component::ComponentCommandHandler};
@@ -138,7 +138,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "create_new_component".to_owned(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -152,7 +152,7 @@ impl GolemCliMcpServer {
                     .await
                 {
                     Ok(_) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
 
                         is_error: None,
                     }),
@@ -183,7 +183,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "update_workers".to_owned(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
@@ -197,7 +197,7 @@ impl GolemCliMcpServer {
                     .await
                 {
                     Ok(_) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
                         is_error: None,
                     }),
                     Err(e) => Ok(CallToolResult {
@@ -230,7 +230,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "redeploy_component_workers".to_owned(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
@@ -241,7 +241,7 @@ impl GolemCliMcpServer {
                 let command_new = ComponentCommandHandler::new(ctx.into());
                 match command_new.cmd_redeploy_workers(req.component_name).await {
                     Ok(_) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
                         is_error: None,
                     }),
                     Err(e) => Ok(CallToolResult {
@@ -274,7 +274,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "build_components".to_owned(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
@@ -294,7 +294,7 @@ impl GolemCliMcpServer {
                 .await
                 {
                     Ok(Ok(_)) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
                         is_error: None,
                     }),
                     Ok(Err(e)) => Ok(CallToolResult {
@@ -331,7 +331,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "filter_templates".to_owned(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
@@ -343,7 +343,7 @@ impl GolemCliMcpServer {
 
                 command_new.cmd_templates(req.filter);
                 Ok(CallToolResult {
-                    content: vec![Content::text("Success")],
+                    content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
                     is_error: None,
                 })
             }
@@ -371,7 +371,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "deploy_components".to_owned(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
@@ -395,7 +395,7 @@ impl GolemCliMcpServer {
                 .await
                 {
                     Ok(Ok(_)) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
                         is_error: None,
                     }),
                     Ok(Err(e)) => Ok(CallToolResult {
@@ -429,7 +429,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "list_components".to_owned(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
@@ -441,7 +441,7 @@ impl GolemCliMcpServer {
 
                 match command_new.cmd_list(req.component_name).await {
                     Ok(_) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
                         is_error: None,
                     }),
                     Err(e) => Ok(CallToolResult {
@@ -474,7 +474,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "clean_components".to_owned(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
@@ -486,7 +486,7 @@ impl GolemCliMcpServer {
 
                 match command_new.cmd_clean(req.component_name).await {
                     Ok(_) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
                         is_error: None,
                     }),
                     Err(e) => Ok(CallToolResult {
@@ -519,7 +519,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "get_component".to_owned(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
@@ -531,7 +531,7 @@ impl GolemCliMcpServer {
 
                 match command_new.cmd_get(req.component_name, req.version).await {
                     Ok(_) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
                         is_error: None,
                     }),
                     Err(e) => Ok(CallToolResult {
@@ -564,7 +564,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "add_dependency_to_a_component".to_string(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
@@ -585,7 +585,7 @@ impl GolemCliMcpServer {
                     .await
                 {
                     Ok(_) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
                         is_error: None,
                     }),
                     Err(e) => Ok(CallToolResult {
@@ -618,7 +618,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "diagnose_components".to_string(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
@@ -630,7 +630,7 @@ impl GolemCliMcpServer {
 
                 match command_new.cmd_diagnose(req.component_name).await {
                     Ok(_) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
                         is_error: None,
                     }),
                     Err(e) => Ok(CallToolResult {

--- a/golem-cli/src/command_handler/mcp_server/tools/component/mod.rs
+++ b/golem-cli/src/command_handler/mcp_server/tools/component/mod.rs
@@ -5,7 +5,7 @@ use crate::command::shared_args::{
 use crate::command_handler::mcp_server::GolemCliMcpServer;
 use crate::log::{McpClient, Output};
 use crate::model::app::DependencyType;
-use crate::model::{ComponentName, WorkerUpdateMode, default_worker_update_mode};
+use crate::model::{ComponentName, WorkerUpdateMode };
 use crate::{command::GolemCliGlobalFlags, command_handler::component::ComponentCommandHandler};
 use console::strip_ansi_codes;
 use golem_templates::model::PackageName;
@@ -51,12 +51,7 @@ pub struct GetComponentTool {
     ///   - <ACCOUNT>/<PROJECT>/<COMPONENT>
     component_name: Option<ComponentName>,
     /// Component version in integer(u64)
-    #[schemars(default="default_component_version")]
     version: Option<u64>,
-}
-
-fn default_component_version() -> Option<u64>{
-    None
 }
 
 #[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
@@ -66,7 +61,7 @@ pub struct UpdateWorkersTool {
     ///   - <PROJECT>/<COMPONENT>
     ///   - <ACCOUNT>/<PROJECT>/<COMPONENT>
     component_name: Option<ComponentName>,
-    #[schemars(default="default_worker_update_mode")]
+    // default Worker update mode is Automatic
     worker_update_mode: WorkerUpdateMode,
 }
 

--- a/golem-cli/src/command_handler/mcp_server/tools/component/mod.rs
+++ b/golem-cli/src/command_handler/mcp_server/tools/component/mod.rs
@@ -1,0 +1,631 @@
+use crate::command::shared_args::{
+    BuildArgs, ComponentOptionalComponentNames, ComponentTemplateName, ForceBuildArg,
+    UpdateOrRedeployArgs,
+};
+use crate::command_handler::mcp_server::GolemCliMcpServer;
+use crate::log::{McpClient, Output};
+use crate::model::app::DependencyType;
+use crate::model::{ComponentName, WorkerUpdateMode, default_worker_update_mode};
+use crate::{command::GolemCliGlobalFlags, command_handler::component::ComponentCommandHandler};
+use console::strip_ansi_codes;
+use golem_templates::model::PackageName;
+use rmcp::handler::server::tool::Parameters;
+use rmcp::model::{CallToolResult, Content};
+use rmcp::{schemars, tool, tool_router, Error as CallToolError, Peer, RoleServer};
+use serde::{Deserialize, Serialize};
+use std::future::Future;
+use std::path::PathBuf;
+use std::sync   ::Arc;
+use url::Url;
+
+pub mod plugin;
+
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct CreateNewComponentTool {
+    /// Template to use to create a new component. Accepted format : <LANGUAGE>/<NAME>
+    template: ComponentTemplateName,
+    /// Package name in the format: (<Namespace>,<Name>), an array
+    component_package_name: PackageName,
+}
+
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct ListComponentTool {
+    /// Accepted formats:
+    ///   - <COMPONENT>
+    ///   - <PROJECT>/<COMPONENT>
+    ///   - <ACCOUNT>/<PROJECT>/<COMPONENT>
+    component_name: Option<ComponentName>,
+}
+
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct CleanComponentTool {
+    
+    component_name: ComponentOptionalComponentNames,
+}
+
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct GetComponentTool {
+    /// Accepted formats:
+    ///   - <COMPONENT>
+    ///   - <PROJECT>/<COMPONENT>
+    ///   - <ACCOUNT>/<PROJECT>/<COMPONENT>
+    component_name: Option<ComponentName>,
+    /// Component version in integer(u64)
+    #[schemars(default="default_component_version")]
+    version: Option<u64>,
+}
+
+fn default_component_version() -> Option<u64>{
+    None
+}
+
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct UpdateWorkersTool {
+    /// Accepted formats:
+    ///   - <COMPONENT>
+    ///   - <PROJECT>/<COMPONENT>
+    ///   - <ACCOUNT>/<PROJECT>/<COMPONENT>
+    component_name: Option<ComponentName>,
+    #[schemars(default="default_worker_update_mode")]
+    worker_update_mode: WorkerUpdateMode,
+}
+
+/// Redeploy all workers of the selected component using the latest version
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct RedeployWorkersTool {
+    /// Accepted formats:
+    ///   - <COMPONENT>
+    ///   - <PROJECT>/<COMPONENT>
+    ///   - <ACCOUNT>/<PROJECT>/<COMPONENT>
+    component_name: Option<ComponentName>,
+}
+
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct BuildComponentTool {
+    component_names: ComponentOptionalComponentNames,
+    build_args: BuildArgs,
+}
+
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct FilterTemplatesComponentTool {
+    filter: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct DeployComponentTool {
+    component_names: ComponentOptionalComponentNames,
+    force_build_arg: ForceBuildArg,
+    update_or_redeploy_args: UpdateOrRedeployArgs,
+}
+
+/// Add or update a component dependency
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct AddDependencyTool {
+    /// The name of the component to which the dependency should be added
+    component_name: Option<ComponentName>,
+
+    /// The name of the component that will be used as the target component
+    target_component_name: Option<ComponentName>,
+
+    /// The path to the local component WASM that will be used as the target
+    target_component_path: Option<PathBuf>,
+
+    /// The URL to the remote component WASM that will be used as the target
+    #[schemars(with = "String")]
+    target_component_url: Option<Url>,
+
+    /// The type of the dependency, defaults to wasm-rpc
+    dependency_type: Option<DependencyType>,
+}
+
+/// Diagnose possible tooling problems
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct DiagnoseComponentTool {
+    component_name: ComponentOptionalComponentNames,
+}
+
+#[tool_router(router= tool_router_component, vis="pub")]
+impl GolemCliMcpServer {
+    #[tool(
+        name = "create_new_component",
+        description = "Create a new golem component in a golem app"
+    )]
+    pub async fn create_new_component(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<CreateNewComponentTool>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "create_new_component".to_owned(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = ComponentCommandHandler::new(ctx.into());
+                match command_new
+                    .cmd_new(Some(req.template), Some(req.component_package_name))
+                    .await
+                {
+                    Ok(_) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+
+                        is_error: None,
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+
+    #[tool(name = "update_workers", description = "Update workers of a golem app")]
+    pub async fn update_workers(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<UpdateWorkersTool>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "update_workers".to_owned(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = ComponentCommandHandler::new(ctx.into());
+                match command_new
+                    .cmd_update_workers(req.component_name, req.worker_update_mode)
+                    .await
+                {
+                    Ok(_) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+                        is_error: None,
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+
+    #[tool(
+        name = "redeploy_component_workers",
+        description = "Redeploy workers of a golem app"
+    )]
+    pub async fn redeploy_component_workers(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<RedeployWorkersTool>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "redeploy_component_workers".to_owned(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = ComponentCommandHandler::new(ctx.into());
+                match command_new.cmd_redeploy_workers(req.component_name).await {
+                    Ok(_) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+                        is_error: None,
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+
+    #[tool(
+        name = "build_components",
+        description = "Build components in a golem app"
+    )]
+    pub async fn build_components(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<BuildComponentTool>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "build_components".to_owned(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = ComponentCommandHandler::new(ctx.into());
+                match tokio::task::spawn_blocking(move || {
+                    let rt = tokio::runtime::Runtime::new().unwrap();
+                    rt.block_on(async {
+                        command_new
+                            .cmd_build(req.component_names, req.build_args)
+                            .await
+                    })
+                })
+                .await
+                {
+                    Ok(Ok(_)) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+                        is_error: None,
+                    }),
+                    Ok(Err(e)) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+
+    #[tool(
+        name = "filter_templates",
+        description = "Filter templates by filter string provided by golem"
+    )]
+    pub async fn filter_templates(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<FilterTemplatesComponentTool>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "filter_templates".to_owned(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = ComponentCommandHandler::new(ctx.into());
+
+                command_new.cmd_templates(req.filter);
+                Ok(CallToolResult {
+                    content: vec![Content::text("Success")],
+                    is_error: None,
+                })
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+
+    #[tool(
+        name = "deploy_components",
+        description = "Deploy components of golem app"
+    )]
+    pub async fn deploy_components(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<DeployComponentTool>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "deploy_components".to_owned(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = ComponentCommandHandler::new(ctx.into());
+                match tokio::task::spawn_blocking(move || {
+                    let rt = tokio::runtime::Runtime::new().unwrap();
+                    rt.block_on(async {
+                        command_new
+                            .cmd_deploy(
+                                req.component_names,
+                                req.force_build_arg,
+                                req.update_or_redeploy_args,
+                            )
+                            .await
+                    })
+                })
+                .await
+                {
+                    Ok(Ok(_)) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+                        is_error: None,
+                    }),
+                    Ok(Err(e)) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+
+    #[tool(name = "list_components", description = "List components in golem app")]
+    pub async fn list_components(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<ListComponentTool>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "list_components".to_owned(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = ComponentCommandHandler::new(ctx.into());
+
+                match command_new.cmd_list(req.component_name).await {
+                    Ok(_) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+                        is_error: None,
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+
+    #[tool(
+        name = "clean_components",
+        description = "Clean components in golem app"
+    )]
+    pub async fn clean_components(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<CleanComponentTool>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "clean_components".to_owned(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = ComponentCommandHandler::new(ctx.into());
+
+                match command_new.cmd_clean(req.component_name).await {
+                    Ok(_) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+                        is_error: None,
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+
+    #[tool(
+        name = "get_component",
+        description = "get component details in golem app"
+    )]
+    pub async fn get_components(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<GetComponentTool>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "get_component".to_owned(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = ComponentCommandHandler::new(ctx.into());
+
+                match command_new.cmd_get(req.component_name, req.version).await {
+                    Ok(_) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+                        is_error: None,
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+
+    #[tool(
+        name = "add_dependency_to_a_component",
+        description = "Add dependency to a component in golem app"
+    )]
+    pub async fn add_dependency_to_a_component(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<AddDependencyTool>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "add_dependency_to_a_component".to_string(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = ComponentCommandHandler::new(ctx.into());
+
+                match command_new
+                    .cmd_add_dependency(
+                        req.component_name,
+                        req.target_component_name,
+                        req.target_component_path,
+                        req.target_component_url,
+                        req.dependency_type,
+                    )
+                    .await
+                {
+                    Ok(_) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+                        is_error: None,
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+
+    #[tool(
+        name = "diagnose_components",
+        description = "Diagnose components in golem app"
+    )]
+    pub async fn diagnose_components(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<DiagnoseComponentTool>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "diagnose_components".to_string(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = ComponentCommandHandler::new(ctx.into());
+
+                match command_new.cmd_diagnose(req.component_name).await {
+                    Ok(_) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+                        is_error: None,
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+}

--- a/golem-cli/src/command_handler/mcp_server/tools/component/mod.rs
+++ b/golem-cli/src/command_handler/mcp_server/tools/component/mod.rs
@@ -3,14 +3,14 @@ use crate::command::shared_args::{
     UpdateOrRedeployArgs,
 };
 use crate::command_handler::mcp_server::GolemCliMcpServer;
-use crate::log::{McpClient, Output};
+use crate::log::{Mcp, Output};
 use crate::model::app::DependencyType;
 use crate::model::{ComponentName, WorkerUpdateMode };
 use crate::{command::GolemCliGlobalFlags, command_handler::component::ComponentCommandHandler};
 use console::strip_ansi_codes;
 use golem_templates::model::PackageName;
 use rmcp::handler::server::tool::Parameters;
-use rmcp::model::{CallToolResult, Content};
+use rmcp::model::{CallToolResult, Content, Meta};
 use rmcp::{schemars, tool, tool_router, Error as CallToolError, Peer, RoleServer};
 use serde::{Deserialize, Serialize};
 use std::future::Future;
@@ -127,6 +127,7 @@ impl GolemCliMcpServer {
     )]
     pub async fn create_new_component(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<CreateNewComponentTool>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -134,9 +135,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "create_new_component".to_owned(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -170,6 +172,7 @@ impl GolemCliMcpServer {
     #[tool(name = "update_workers", description = "Update workers of a golem app")]
     pub async fn update_workers(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<UpdateWorkersTool>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -177,9 +180,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "update_workers".to_owned(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
@@ -215,6 +219,7 @@ impl GolemCliMcpServer {
     )]
     pub async fn redeploy_component_workers(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<RedeployWorkersTool>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -222,9 +227,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "redeploy_component_workers".to_owned(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
@@ -257,6 +263,7 @@ impl GolemCliMcpServer {
     )]
     pub async fn build_components(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<BuildComponentTool>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -264,9 +271,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "build_components".to_owned(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
@@ -312,6 +320,7 @@ impl GolemCliMcpServer {
     )]
     pub async fn filter_templates(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<FilterTemplatesComponentTool>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -319,9 +328,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "filter_templates".to_owned(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
@@ -350,6 +360,7 @@ impl GolemCliMcpServer {
     )]
     pub async fn deploy_components(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<DeployComponentTool>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -357,9 +368,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "deploy_components".to_owned(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
@@ -406,6 +418,7 @@ impl GolemCliMcpServer {
     #[tool(name = "list_components", description = "List components in golem app")]
     pub async fn list_components(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<ListComponentTool>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -413,9 +426,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "list_components".to_owned(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
@@ -449,6 +463,7 @@ impl GolemCliMcpServer {
     )]
     pub async fn clean_components(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<CleanComponentTool>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -456,9 +471,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "clean_components".to_owned(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
@@ -492,6 +508,7 @@ impl GolemCliMcpServer {
     )]
     pub async fn get_components(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<GetComponentTool>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -499,9 +516,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "get_component".to_owned(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
@@ -535,6 +553,7 @@ impl GolemCliMcpServer {
     )]
     pub async fn add_dependency_to_a_component(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<AddDependencyTool>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -542,9 +561,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "add_dependency_to_a_component".to_string(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
@@ -587,6 +607,7 @@ impl GolemCliMcpServer {
     )]
     pub async fn diagnose_components(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<DiagnoseComponentTool>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -594,9 +615,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "diagnose_components".to_string(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now

--- a/golem-cli/src/command_handler/mcp_server/tools/component/plugin.rs
+++ b/golem-cli/src/command_handler/mcp_server/tools/component/plugin.rs
@@ -1,0 +1,258 @@
+use crate::command::shared_args::ComponentOptionalComponentName;
+use crate::command::GolemCliGlobalFlags;
+use crate::command_handler::component::plugin::ComponentPluginCommandHandler;
+use crate::command_handler::mcp_server::GolemCliMcpServer;
+use crate::log::{McpClient, Output};
+use console::strip_ansi_codes;
+use golem_common::model::PluginInstallationId;
+use rmcp::handler::server::tool::Parameters;
+use rmcp::model::{CallToolResult, Content};
+use rmcp::{schemars, tool, tool_router, Error as CallToolError, Peer, RoleServer};
+use serde::{Deserialize, Serialize};
+use std::future::Future;
+use std::sync::Arc;
+
+/// Install a plugin for selected component
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct Install {
+    component_name: ComponentOptionalComponentName,
+    /// The plugin to install
+    plugin_name: String,
+    /// The version of the plugin to install
+    plugin_version: String,
+    /// Priority of the plugin - largest priority is applied first
+    priority: i32,
+    /// List of parameters (key-value pairs) passed to the plugin
+    param: Vec<(String, String)>,
+}
+
+/// Get the installed plugins of the component
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+
+pub struct Get {
+    component_name: ComponentOptionalComponentName,
+    /// The version of the component
+    version: Option<u64>,
+}
+
+/// Update component plugin
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct Update {
+    /// The component to update the plugin for
+    component_name: ComponentOptionalComponentName,
+    /// Installation id of the plugin to update
+    #[schemars(with = "String")]
+    installation_id: PluginInstallationId,
+    /// Updated priority of the plugin - largest priority is applied first
+    priority: i32,
+    /// Updated list of parameters (key-value pairs) passed to the plugin
+    param: Vec<(String, String)>,
+}
+
+/// Uninstall a plugin for selected component
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct Uninstall {
+    /// The component to uninstall the plugin from
+    component_name: ComponentOptionalComponentName,
+    /// Installation id of the plugin to uninstall
+    #[schemars(with = "String")]
+    installation_id: PluginInstallationId,
+}
+
+#[tool_router(router= tool_router_component_plugin, vis="pub")]
+impl GolemCliMcpServer {
+    #[tool(
+        name = "install_component_plugin",
+        description = "Install plugin in a golem app Component"
+    )]
+    pub async fn install_component_plugin(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<Install>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "install_component_plugin".to_owned(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = ComponentPluginCommandHandler::new(ctx.into());
+                match command_new
+                    .cmd_install(
+                        req.component_name.component_name,
+                        req.plugin_name,
+                        req.plugin_version,
+                        req.priority,
+                        req.param,
+                    )
+                    .await
+                {
+                    Ok(_) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+
+                        is_error: None,
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+
+    #[tool(
+        name = "get_component_plugin",
+        description = "Get plugin in a golem app Component"
+    )]
+    pub async fn get_component_plugin(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<Get>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "get_component_plugin".to_owned(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = ComponentPluginCommandHandler::new(ctx.into());
+                match command_new
+                    .cmd_get(req.component_name.component_name, req.version)
+                    .await
+                {
+                    Ok(_) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+
+                        is_error: None,
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+
+    #[tool(
+        name = "uninstall_component_plugin",
+        description = "UnInstall plugin in a golem app Component"
+    )]
+    pub async fn uninstall_component_plugin(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<Uninstall>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "uninstall_component_plugin".to_owned(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = ComponentPluginCommandHandler::new(ctx.into());
+                match command_new
+                    .cmd_uninstall(req.component_name.component_name, req.installation_id)
+                    .await
+                {
+                    Ok(_) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+
+                        is_error: None,
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+
+    #[tool(
+        name = "update_component_plugin",
+        description = "Update plugin in a golem app Component"
+    )]
+    pub async fn update_component_plugin(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<Update>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "update_component_plugin".to_owned(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = ComponentPluginCommandHandler::new(ctx.into());
+                match command_new
+                    .cmd_update(
+                        req.component_name.component_name,
+                        req.installation_id,
+                        req.priority,
+                        req.param,
+                    )
+                    .await
+                {
+                    Ok(_) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+
+                        is_error: None,
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+}

--- a/golem-cli/src/command_handler/mcp_server/tools/component/plugin.rs
+++ b/golem-cli/src/command_handler/mcp_server/tools/component/plugin.rs
@@ -2,7 +2,7 @@ use crate::command::shared_args::ComponentOptionalComponentName;
 use crate::command::GolemCliGlobalFlags;
 use crate::command_handler::component::plugin::ComponentPluginCommandHandler;
 use crate::command_handler::mcp_server::GolemCliMcpServer;
-use crate::log::{Mcp, Output};
+use crate::log::{get_mcp_tool_output, Mcp, Output};
 use console::strip_ansi_codes;
 use golem_common::model::PluginInstallationId;
 use rmcp::handler::server::tool::Parameters;
@@ -78,7 +78,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "install_component_plugin".to_owned(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -98,7 +98,7 @@ impl GolemCliMcpServer {
                     .await
                 {
                     Ok(_) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
 
                         is_error: None,
                     }),
@@ -132,7 +132,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "get_component_plugin".to_owned(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -146,7 +146,7 @@ impl GolemCliMcpServer {
                     .await
                 {
                     Ok(_) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
 
                         is_error: None,
                     }),
@@ -180,7 +180,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "uninstall_component_plugin".to_owned(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -194,7 +194,7 @@ impl GolemCliMcpServer {
                     .await
                 {
                     Ok(_) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
 
                         is_error: None,
                     }),
@@ -228,7 +228,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "update_component_plugin".to_owned(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -247,7 +247,7 @@ impl GolemCliMcpServer {
                     .await
                 {
                     Ok(_) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
 
                         is_error: None,
                     }),

--- a/golem-cli/src/command_handler/mcp_server/tools/component/plugin.rs
+++ b/golem-cli/src/command_handler/mcp_server/tools/component/plugin.rs
@@ -2,11 +2,11 @@ use crate::command::shared_args::ComponentOptionalComponentName;
 use crate::command::GolemCliGlobalFlags;
 use crate::command_handler::component::plugin::ComponentPluginCommandHandler;
 use crate::command_handler::mcp_server::GolemCliMcpServer;
-use crate::log::{McpClient, Output};
+use crate::log::{Mcp, Output};
 use console::strip_ansi_codes;
 use golem_common::model::PluginInstallationId;
 use rmcp::handler::server::tool::Parameters;
-use rmcp::model::{CallToolResult, Content};
+use rmcp::model::{CallToolResult, Content, Meta};
 use rmcp::{schemars, tool, tool_router, Error as CallToolError, Peer, RoleServer};
 use serde::{Deserialize, Serialize};
 use std::future::Future;
@@ -67,6 +67,7 @@ impl GolemCliMcpServer {
     )]
     pub async fn install_component_plugin(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<Install>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -74,9 +75,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "install_component_plugin".to_owned(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -119,6 +121,7 @@ impl GolemCliMcpServer {
     )]
     pub async fn get_component_plugin(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<Get>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -126,9 +129,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "get_component_plugin".to_owned(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -165,6 +169,7 @@ impl GolemCliMcpServer {
     )]
     pub async fn uninstall_component_plugin(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<Uninstall>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -172,9 +177,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "uninstall_component_plugin".to_owned(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -211,6 +217,7 @@ impl GolemCliMcpServer {
     )]
     pub async fn update_component_plugin(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<Update>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -218,9 +225,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "update_component_plugin".to_owned(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server

--- a/golem-cli/src/command_handler/mcp_server/tools/mod.rs
+++ b/golem-cli/src/command_handler/mcp_server/tools/mod.rs
@@ -1,3 +1,19 @@
+use console::strip_ansi_codes;
+use rmcp::{
+    handler::server::tool::Parameters,
+    model::{CallToolResult, Content, Meta},
+    service::RequestContext,
+    tool, tool_router, Error as CallToolError, Peer, RoleServer, ServerHandler,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    command::GolemCliGlobalFlags,
+    command_handler::mcp_server::GolemCliMcpServer,
+    log::{Mcp, Output},
+};
+use std::future::Future;
+
 pub mod api;
 pub mod app;
 pub mod cloud;
@@ -6,3 +22,38 @@ pub mod plugin;
 pub mod profile;
 pub mod repl;
 pub mod worker;
+
+/// Run custom command
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct ListTools {}
+
+#[tool_router(router= tool_router_list_tools, vis="pub")]
+impl GolemCliMcpServer {
+    #[tool(
+        name = "list_golem_mcp_server_tools",
+        description = "tool to list tools this golem-cli mcp server"
+    )]
+    pub async fn list_golem_mcp_server_tools(
+        &self,
+        _meta: Meta,
+        context: RequestContext<RoleServer>,
+        _client: Peer<RoleServer>,
+        Parameters(_): Parameters<ListTools>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let tools = self.list_tools(None, context).await;
+        match tools {
+            Ok(tools_result) => Ok(CallToolResult {
+                content: tools_result
+                    .tools
+                    .into_iter()
+                    .map(|tool| Content::text(tool.schema_as_json_value().to_string()))
+                    .collect(),
+                is_error: None,
+            }),
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+}

--- a/golem-cli/src/command_handler/mcp_server/tools/mod.rs
+++ b/golem-cli/src/command_handler/mcp_server/tools/mod.rs
@@ -1,0 +1,8 @@
+pub mod api;
+pub mod app;
+pub mod cloud;
+pub mod component;
+pub mod plugin;
+pub mod profile;
+pub mod repl;
+pub mod worker;

--- a/golem-cli/src/command_handler/mcp_server/tools/plugin.rs
+++ b/golem-cli/src/command_handler/mcp_server/tools/plugin.rs
@@ -2,11 +2,11 @@ use crate::command::shared_args::PluginScopeArgs;
 use crate::command::GolemCliGlobalFlags;
 use crate::command_handler::mcp_server::GolemCliMcpServer;
 use crate::command_handler::plugin::PluginCommandHandler;
-use crate::log::{McpClient, Output};
+use crate::log::{Mcp, Output};
 use crate::model::PathBufOrStdin;
 use console::strip_ansi_codes;
 use rmcp::handler::server::tool::Parameters;
-use rmcp::model::{CallToolResult, Content};
+use rmcp::model::{CallToolResult, Content, Meta};
 use rmcp::{schemars, tool, tool_router, Error as CallToolError, Peer, RoleServer};
 use serde::{Deserialize, Serialize};
 use std::future::Future;
@@ -53,6 +53,7 @@ impl GolemCliMcpServer {
     )]
     pub async fn list_components_for_scope(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<List>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -60,9 +61,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "list_components_for_scope".to_owned(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
@@ -96,6 +98,7 @@ impl GolemCliMcpServer {
     )]
     pub async fn get_plugin(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<Unregister>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -103,9 +106,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "get_plugin".to_string(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
@@ -136,6 +140,7 @@ impl GolemCliMcpServer {
     #[tool(name = "register_plugin", description = "Register a new plugin")]
     pub async fn register_plugin(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<Register>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -143,9 +148,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "register_plugin".to_string(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
@@ -176,6 +182,7 @@ impl GolemCliMcpServer {
     #[tool(name = "unregister_plugin", description = "Unregister a new plugin")]
     pub async fn unregister_plugin(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<Unregister>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -183,9 +190,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "unregister_plugin".to_string(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now

--- a/golem-cli/src/command_handler/mcp_server/tools/plugin.rs
+++ b/golem-cli/src/command_handler/mcp_server/tools/plugin.rs
@@ -1,0 +1,218 @@
+use crate::command::shared_args::PluginScopeArgs;
+use crate::command::GolemCliGlobalFlags;
+use crate::command_handler::mcp_server::GolemCliMcpServer;
+use crate::command_handler::plugin::PluginCommandHandler;
+use crate::log::{McpClient, Output};
+use crate::model::PathBufOrStdin;
+use console::strip_ansi_codes;
+use rmcp::handler::server::tool::Parameters;
+use rmcp::model::{CallToolResult, Content};
+use rmcp::{schemars, tool, tool_router, Error as CallToolError, Peer, RoleServer};
+use serde::{Deserialize, Serialize};
+use std::future::Future;
+use std::sync::Arc;
+
+/// List component for the select scope
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct List {
+    /// The scope to list components from
+    scope: PluginScopeArgs,
+}
+
+/// Get information about a registered plugin
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct Get {
+    /// Plugin name
+    plugin_name: String,
+    /// Plugin version
+    version: String,
+}
+
+/// Register a new plugin
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct Register {
+    scope: PluginScopeArgs,
+    /// Path to the plugin manifest JSON or '-' to use STDIN
+    manifest: PathBufOrStdin,
+}
+
+/// Unregister a plugin
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct Unregister {
+    /// Plugin name
+    plugin_name: String,
+    /// Plugin version
+    version: String,
+}
+
+#[tool_router(router= tool_router_plugin, vis="pub")]
+impl GolemCliMcpServer {
+    #[tool(
+        name = "list_components_for_scope",
+        description = "List component for the select scope"
+    )]
+    pub async fn list_components_for_scope(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<List>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "list_components_for_scope".to_owned(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = PluginCommandHandler::new(ctx.into());
+
+                match command_new.cmd_list(req.scope).await {
+                    Ok(_) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+                        is_error: None,
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+
+    #[tool(
+        name = "get_plugin",
+        description = "Get information about a registered plugin"
+    )]
+    pub async fn get_plugin(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<Unregister>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "get_plugin".to_string(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = PluginCommandHandler::new(ctx.into());
+
+                match command_new.cmd_get(req.plugin_name, req.version).await {
+                    Ok(_) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+                        is_error: None,
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+
+    #[tool(name = "register_plugin", description = "Register a new plugin")]
+    pub async fn register_plugin(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<Register>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "register_plugin".to_string(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = PluginCommandHandler::new(ctx.into());
+
+                match command_new.cmd_register(req.scope, req.manifest).await {
+                    Ok(_) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+                        is_error: None,
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+
+    #[tool(name = "unregister_plugin", description = "Unregister a new plugin")]
+    pub async fn unregister_plugin(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<Unregister>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "unregister_plugin".to_string(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = PluginCommandHandler::new(ctx.into());
+
+                match command_new
+                    .cmd_unregister(req.plugin_name, req.version)
+                    .await
+                {
+                    Ok(_) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+                        is_error: None,
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+}

--- a/golem-cli/src/command_handler/mcp_server/tools/plugin.rs
+++ b/golem-cli/src/command_handler/mcp_server/tools/plugin.rs
@@ -2,7 +2,7 @@ use crate::command::shared_args::PluginScopeArgs;
 use crate::command::GolemCliGlobalFlags;
 use crate::command_handler::mcp_server::GolemCliMcpServer;
 use crate::command_handler::plugin::PluginCommandHandler;
-use crate::log::{Mcp, Output};
+use crate::log::{get_mcp_tool_output, Mcp, Output};
 use crate::model::PathBufOrStdin;
 use console::strip_ansi_codes;
 use rmcp::handler::server::tool::Parameters;
@@ -64,7 +64,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "list_components_for_scope".to_owned(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
@@ -76,7 +76,7 @@ impl GolemCliMcpServer {
 
                 match command_new.cmd_list(req.scope).await {
                     Ok(_) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
                         is_error: None,
                     }),
                     Err(e) => Ok(CallToolResult {
@@ -109,7 +109,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "get_plugin".to_string(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
@@ -121,7 +121,7 @@ impl GolemCliMcpServer {
 
                 match command_new.cmd_get(req.plugin_name, req.version).await {
                     Ok(_) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
                         is_error: None,
                     }),
                     Err(e) => Ok(CallToolResult {
@@ -151,7 +151,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "register_plugin".to_string(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
@@ -163,7 +163,7 @@ impl GolemCliMcpServer {
 
                 match command_new.cmd_register(req.scope, req.manifest).await {
                     Ok(_) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
                         is_error: None,
                     }),
                     Err(e) => Ok(CallToolResult {
@@ -193,7 +193,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "unregister_plugin".to_string(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
@@ -208,7 +208,7 @@ impl GolemCliMcpServer {
                     .await
                 {
                     Ok(_) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
                         is_error: None,
                     }),
                     Err(e) => Ok(CallToolResult {

--- a/golem-cli/src/command_handler/mcp_server/tools/profile/config.rs
+++ b/golem-cli/src/command_handler/mcp_server/tools/profile/config.rs
@@ -2,7 +2,7 @@ use crate::command::GolemCliGlobalFlags;
 use crate::command_handler::mcp_server::GolemCliMcpServer;
 use crate::command_handler::profile::config::ProfileConfigCommandHandler;
 use crate::config::ProfileName;
-use crate::log::{Mcp, Output};
+use crate::log::{get_mcp_tool_output, Mcp, Output};
 use crate::model::Format;
 use console::strip_ansi_codes;
 use rmcp::handler::server::tool::Parameters;
@@ -40,7 +40,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "set_default_output_format_profile".to_owned(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -51,7 +51,7 @@ impl GolemCliMcpServer {
                 let command_new = ProfileConfigCommandHandler::new(ctx.into());
                 match command_new.cmd_set_format(req.profile_name, req.format) {
                     Ok(_) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
 
                         is_error: None,
                     }),

--- a/golem-cli/src/command_handler/mcp_server/tools/profile/config.rs
+++ b/golem-cli/src/command_handler/mcp_server/tools/profile/config.rs
@@ -1,0 +1,68 @@
+use crate::command::GolemCliGlobalFlags;
+use crate::command_handler::mcp_server::GolemCliMcpServer;
+use crate::command_handler::profile::config::ProfileConfigCommandHandler;
+use crate::config::ProfileName;
+use crate::log::{McpClient, Output};
+use crate::model::Format;
+use console::strip_ansi_codes;
+use rmcp::handler::server::tool::Parameters;
+use rmcp::model::{CallToolResult, Content};
+use rmcp::{schemars, tool, tool_router, Error as CallToolError, Peer, RoleServer};
+use serde::{Deserialize, Serialize};
+use std::future::Future;
+use std::sync::Arc;
+
+/// Set default output format for the requested profile
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct SetFormat {
+    /// Profile name
+    profile_name: ProfileName,
+    /// CLI output format
+    format: Format,
+}
+
+#[tool_router(router= tool_router_profile_config, vis="pub")]
+impl GolemCliMcpServer {
+    #[tool(
+        name = "set_default_output_format_profile",
+        description = "Set default output format for the requested profile"
+    )]
+    pub async fn set_default_output_format_profile(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<SetFormat>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "set_default_output_format_profile".to_owned(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = ProfileConfigCommandHandler::new(ctx.into());
+                match command_new.cmd_set_format(req.profile_name, req.format) {
+                    Ok(_) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+
+                        is_error: None,
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+}

--- a/golem-cli/src/command_handler/mcp_server/tools/profile/config.rs
+++ b/golem-cli/src/command_handler/mcp_server/tools/profile/config.rs
@@ -2,11 +2,11 @@ use crate::command::GolemCliGlobalFlags;
 use crate::command_handler::mcp_server::GolemCliMcpServer;
 use crate::command_handler::profile::config::ProfileConfigCommandHandler;
 use crate::config::ProfileName;
-use crate::log::{McpClient, Output};
+use crate::log::{Mcp, Output};
 use crate::model::Format;
 use console::strip_ansi_codes;
 use rmcp::handler::server::tool::Parameters;
-use rmcp::model::{CallToolResult, Content};
+use rmcp::model::{CallToolResult, Content, Meta};
 use rmcp::{schemars, tool, tool_router, Error as CallToolError, Peer, RoleServer};
 use serde::{Deserialize, Serialize};
 use std::future::Future;
@@ -29,6 +29,7 @@ impl GolemCliMcpServer {
     )]
     pub async fn set_default_output_format_profile(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<SetFormat>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -36,9 +37,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "set_default_output_format_profile".to_owned(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server

--- a/golem-cli/src/command_handler/mcp_server/tools/profile/mod.rs
+++ b/golem-cli/src/command_handler/mcp_server/tools/profile/mod.rs
@@ -2,7 +2,7 @@ use crate::command::GolemCliGlobalFlags;
 use crate::command_handler::mcp_server::GolemCliMcpServer;
 use crate::command_handler::profile::ProfileCommandHandler;
 use crate::config::ProfileName;
-use crate::log::{Mcp, Output};
+use crate::log::{get_mcp_tool_output, Mcp, Output};
 use crate::model::Format;
 use console::strip_ansi_codes;
 use rmcp::handler::server::tool::Parameters;
@@ -92,7 +92,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "create_new_global_profile".to_owned(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -112,7 +112,7 @@ impl GolemCliMcpServer {
                     None // req.static_token, not good to allow in mcp, so oauth flow will take place
                 ) {
                     Ok(_) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
 
                         is_error: None,
                     }),
@@ -143,7 +143,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "list_global_profiles".to_owned(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -154,7 +154,7 @@ impl GolemCliMcpServer {
                 let command_new = ProfileCommandHandler::new(ctx.into());
                 match command_new.cmd_list() {
                     Ok(_) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
 
                         is_error: None,
                     }),
@@ -188,7 +188,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "Show_global_profile_details".to_owned(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -199,7 +199,7 @@ impl GolemCliMcpServer {
                 let command_new = ProfileCommandHandler::new(ctx.into());
                 match command_new.cmd_get(req.profile_name) {
                     Ok(_) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
 
                         is_error: None,
                     }),
@@ -230,7 +230,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "remove_profile".to_owned(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -241,7 +241,7 @@ impl GolemCliMcpServer {
                 let command_new = ProfileCommandHandler::new(ctx.into());
                 match command_new.cmd_delete(req.profile_name) {
                     Ok(_) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
 
                         is_error: None,
                     }),
@@ -275,7 +275,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "switch_profile".to_owned(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -286,7 +286,7 @@ impl GolemCliMcpServer {
                 let command_new = ProfileCommandHandler::new(ctx.into());
                 match command_new.cmd_switch(req.profile_name) {
                     Ok(_) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
 
                         is_error: None,
                     }),

--- a/golem-cli/src/command_handler/mcp_server/tools/profile/mod.rs
+++ b/golem-cli/src/command_handler/mcp_server/tools/profile/mod.rs
@@ -2,11 +2,11 @@ use crate::command::GolemCliGlobalFlags;
 use crate::command_handler::mcp_server::GolemCliMcpServer;
 use crate::command_handler::profile::ProfileCommandHandler;
 use crate::config::ProfileName;
-use crate::log::{McpClient, Output};
+use crate::log::{Mcp, Output};
 use crate::model::Format;
 use console::strip_ansi_codes;
 use rmcp::handler::server::tool::Parameters;
-use rmcp::model::{CallToolResult, Content};
+use rmcp::model::{CallToolResult, Content, Meta};
 use rmcp::{schemars, tool, tool_router, Error as CallToolError, Peer, RoleServer};
 use serde::{Deserialize, Serialize};
 use std::future::Future;
@@ -81,6 +81,7 @@ impl GolemCliMcpServer {
     )]
     pub async fn create_new_global_profile(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<New>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -88,9 +89,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "create_new_global_profile".to_owned(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -130,6 +132,7 @@ impl GolemCliMcpServer {
     #[tool(name = "list_global_profiles", description = "List global profiles")]
     pub async fn list_global_profiles(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(_): Parameters<List>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -137,9 +140,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "list_global_profiles".to_owned(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -173,6 +177,7 @@ impl GolemCliMcpServer {
     )]
     pub async fn show_global_profile_details(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<Get>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -180,9 +185,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "Show_global_profile_details".to_owned(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -213,6 +219,7 @@ impl GolemCliMcpServer {
     #[tool(name = "remove_profile", description = "Remove global profile")]
     pub async fn remove_profile(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<Delete>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -220,9 +227,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "remove_profile".to_owned(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -256,6 +264,7 @@ impl GolemCliMcpServer {
     )]
     pub async fn switch_profile(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<Switch>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -263,9 +272,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "switch_profile".to_owned(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server

--- a/golem-cli/src/command_handler/mcp_server/tools/profile/mod.rs
+++ b/golem-cli/src/command_handler/mcp_server/tools/profile/mod.rs
@@ -1,0 +1,295 @@
+use crate::command::GolemCliGlobalFlags;
+use crate::command_handler::mcp_server::GolemCliMcpServer;
+use crate::command_handler::profile::ProfileCommandHandler;
+use crate::config::ProfileName;
+use crate::log::{McpClient, Output};
+use crate::model::Format;
+use console::strip_ansi_codes;
+use rmcp::handler::server::tool::Parameters;
+use rmcp::model::{CallToolResult, Content};
+use rmcp::{schemars, tool, tool_router, Error as CallToolError, Peer, RoleServer};
+use serde::{Deserialize, Serialize};
+use std::future::Future;
+use std::sync::Arc;
+use url::Url;
+// use uuid::Uuid;
+
+pub mod config;
+
+/// Create new global profile, call without <PROFILE_NAME> for interactive setup
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct New {
+    /// Name of the newly created profile
+    name: Option<ProfileName>,
+    /// Switch to the profile after creation
+    set_active: bool,
+    /// URL of Golem Component service
+    #[schemars(with = "String")]
+    component_url: Option<Url>,
+    /// URL of Golem Worker service, if not provided defaults to component-url
+    #[schemars(with = "String")]
+    worker_url: Option<Url>,
+    /// URL of Golem Cloud service, if not provided defaults to component-url
+    #[schemars(with = "String")]
+    cloud_url: Option<Url>,
+    /// Default output format
+    default_format: Format,
+    
+    /// Token to use for authenticating against Golem. If not provided an OAuth2 flow will be performed when authentication is needed for the first time.
+    // #[schemars(with = "String")]
+    // static_token: Option<Uuid>, disabled
+
+    /// Accept invalid certificates.
+    ///
+    /// Disables certificate validation.
+    /// Warning! Any certificate will be trusted for use.
+    /// This includes expired certificates.
+    /// This introduces significant vulnerabilities, and should only be used as a last resort.
+    allow_insecure: bool,
+}
+
+/// List global profiles
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct List {}
+
+/// Set the active global default profile
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct Switch {
+    /// Profile name to switch to
+    profile_name: ProfileName,
+}
+
+/// Show global profile details
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct Get {
+    /// Name of profile to show, shows active profile if not specified.
+    profile_name: Option<ProfileName>,
+}
+
+/// Remove global profile
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct Delete {
+    /// Profile name to delete
+    profile_name: ProfileName,
+}
+
+#[tool_router(router= tool_router_profile, vis="pub")]
+impl GolemCliMcpServer {
+    #[tool(
+        name = "create_new_global_profile",
+        description = "Create new global profile"
+    )]
+    pub async fn create_new_global_profile(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<New>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "create_new_global_profile".to_owned(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = ProfileCommandHandler::new(ctx.into());
+                match command_new.cmd_new(
+                    req.name,
+                    req.set_active,
+                    req.component_url,
+                    req.worker_url,
+                    req.cloud_url,
+                    req.default_format,
+                    req.allow_insecure,
+                    None // req.static_token, not good to allow in mcp, so oauth flow will take place
+                ) {
+                    Ok(_) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+
+                        is_error: None,
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+
+    #[tool(name = "list_global_profiles", description = "List global profiles")]
+    pub async fn list_global_profiles(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(_): Parameters<List>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "list_global_profiles".to_owned(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = ProfileCommandHandler::new(ctx.into());
+                match command_new.cmd_list() {
+                    Ok(_) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+
+                        is_error: None,
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+
+    #[tool(
+        name = "show_global_profile_details",
+        description = "Show global profile details"
+    )]
+    pub async fn show_global_profile_details(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<Get>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "Show_global_profile_details".to_owned(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = ProfileCommandHandler::new(ctx.into());
+                match command_new.cmd_get(req.profile_name) {
+                    Ok(_) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+
+                        is_error: None,
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+
+    #[tool(name = "remove_profile", description = "Remove global profile")]
+    pub async fn remove_profile(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<Delete>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "remove_profile".to_owned(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = ProfileCommandHandler::new(ctx.into());
+                match command_new.cmd_delete(req.profile_name) {
+                    Ok(_) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+
+                        is_error: None,
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+
+    #[tool(
+        name = "switch_profile",
+        description = "Set the active global default profile"
+    )]
+    pub async fn switch_profile(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<Switch>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "switch_profile".to_owned(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = ProfileCommandHandler::new(ctx.into());
+                match command_new.cmd_switch(req.profile_name) {
+                    Ok(_) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+
+                        is_error: None,
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+}

--- a/golem-cli/src/command_handler/mcp_server/tools/repl.rs
+++ b/golem-cli/src/command_handler/mcp_server/tools/repl.rs
@@ -1,0 +1,75 @@
+use crate::command::shared_args::ComponentOptionalComponentName;
+use crate::command::GolemCliGlobalFlags;
+use crate::command_handler::mcp_server::GolemCliMcpServer;
+use crate::command_handler::rib_repl::RibReplHandler;
+use crate::log::{McpClient, Output};
+use console::strip_ansi_codes;
+use rmcp::handler::server::tool::Parameters;
+use rmcp::model::{CallToolResult, Content};
+use rmcp::{schemars, tool, tool_router, Error as CallToolError, Peer, RoleServer};
+use serde::{Deserialize, Serialize};
+use std::future::Future;
+use std::sync::Arc;
+
+/// Start Rib REPL for a selected component
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct Repl {
+    component_name: ComponentOptionalComponentName,
+    /// Optional component version to use, defaults to latest component version
+    version: Option<u64>,
+}
+
+#[tool_router(router= tool_router_repl, vis="pub")]
+impl GolemCliMcpServer {
+    #[tool(
+        name = "start_rib_repl",
+        description = "Start Rib REPL for a selected component"
+    )]
+    pub async fn start_rib_repl(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<Repl>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "start_rib_repl".to_owned(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = RibReplHandler::new(ctx.into());
+                match tokio::task::spawn_blocking(move || {
+                    let rt = tokio::runtime::Runtime::new().unwrap();
+                    rt.block_on(async {
+                        command_new
+                            .cmd_repl(req.component_name.component_name, req.version)
+                            .await
+                    })
+                })
+                .await
+                {
+                    Ok(_) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+
+                        is_error: None,
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+}

--- a/golem-cli/src/command_handler/mcp_server/tools/repl.rs
+++ b/golem-cli/src/command_handler/mcp_server/tools/repl.rs
@@ -2,7 +2,7 @@ use crate::command::shared_args::ComponentOptionalComponentName;
 use crate::command::GolemCliGlobalFlags;
 use crate::command_handler::mcp_server::GolemCliMcpServer;
 use crate::command_handler::rib_repl::RibReplHandler;
-use crate::log::{Mcp, Output};
+use crate::log::{get_mcp_tool_output, Mcp, Output};
 use console::strip_ansi_codes;
 use rmcp::handler::server::tool::Parameters;
 use rmcp::model::{CallToolResult, Content, Meta};
@@ -38,7 +38,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "start_rib_repl".to_owned(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -58,7 +58,7 @@ impl GolemCliMcpServer {
                 .await
                 {
                     Ok(_) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
 
                         is_error: None,
                     }),

--- a/golem-cli/src/command_handler/mcp_server/tools/repl.rs
+++ b/golem-cli/src/command_handler/mcp_server/tools/repl.rs
@@ -2,10 +2,10 @@ use crate::command::shared_args::ComponentOptionalComponentName;
 use crate::command::GolemCliGlobalFlags;
 use crate::command_handler::mcp_server::GolemCliMcpServer;
 use crate::command_handler::rib_repl::RibReplHandler;
-use crate::log::{McpClient, Output};
+use crate::log::{Mcp, Output};
 use console::strip_ansi_codes;
 use rmcp::handler::server::tool::Parameters;
-use rmcp::model::{CallToolResult, Content};
+use rmcp::model::{CallToolResult, Content, Meta};
 use rmcp::{schemars, tool, tool_router, Error as CallToolError, Peer, RoleServer};
 use serde::{Deserialize, Serialize};
 use std::future::Future;
@@ -27,6 +27,7 @@ impl GolemCliMcpServer {
     )]
     pub async fn start_rib_repl(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<Repl>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -34,9 +35,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "start_rib_repl".to_owned(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server

--- a/golem-cli/src/command_handler/mcp_server/tools/worker.rs
+++ b/golem-cli/src/command_handler/mcp_server/tools/worker.rs
@@ -1,0 +1,735 @@
+use crate::command::shared_args::{
+    ComponentOptionalComponentName, NewWorkerArgument, StreamArgs, WorkerFunctionArgument,
+    WorkerFunctionName, WorkerNameArg,
+};
+use crate::command::GolemCliGlobalFlags;
+use crate::command_handler::mcp_server::GolemCliMcpServer;
+use crate::command_handler::worker::WorkerCommandHandler;
+use crate::log::{McpClient, Output};
+use crate::model::{IdempotencyKey, WorkerUpdateMode};
+use console::strip_ansi_codes;
+use rmcp::handler::server::tool::Parameters;
+use rmcp::model::{CallToolResult, Content};
+use rmcp::{schemars, tool, tool_router, Error as CallToolError, Peer, RoleServer};
+use serde::{Deserialize, Serialize};
+use std::future::Future;
+use std::sync::Arc;
+
+/// Create new worker
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct New {
+    worker_name: WorkerNameArg,
+    /// Worker arguments
+    arguments: Vec<NewWorkerArgument>,
+    /// Worker environment variables
+    env: Vec<(String, String)>,
+}
+
+// TODO: json args
+/// Invoke (or enqueue invocation for) worker
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct Invoke {
+    worker_name: WorkerNameArg,
+    /// Worker function name to invoke
+    function_name: WorkerFunctionName,
+    /// Worker function arguments in WAVE format
+    arguments: Vec<WorkerFunctionArgument>,
+    /// Enqueue invocation, and do not wait for it
+    enqueue: bool,
+    /// Set idempotency key for the call, use "-" for auto generated key
+    idempotency_key: Option<IdempotencyKey>,
+    /// Connect to the worker before invoke (the worker must already exist)
+    /// and live stream its standard output, error and log channels
+    stream: bool,
+    stream_args: StreamArgs,
+}
+
+/// Get worker metadata
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct Get {
+    worker_name: WorkerNameArg,
+}
+
+/// Deletes a worker
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct Delete {
+    worker_name: WorkerNameArg,
+}
+
+/// List worker metadata
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct List {
+    component_name: ComponentOptionalComponentName,
+    /// Filter for worker metadata in form of `property op value`.
+    ///
+    /// Filter examples: `name = worker-name`, `version >= 0`, `status = Running`, `env.var1 = value`.
+    /// Can be used multiple times (AND condition is applied between them)
+    filter: Vec<String>,
+
+    /// Cursor position, if not provided, starts from the beginning.
+    ///
+    /// Cursor can be used to get the next page of results, use the cursor returned
+    /// in the previous response.
+    /// The cursor has the format 'layer/position' where both layer and position are numbers.
+    // scan_cursor: Option<ScanCursor>,
+    // TODO:// need changes in golem repo, scan_cursor: Option<ScanCursor>,
+
+    /// The maximum the number of returned workers, returns all values is not specified.
+    /// When multiple component is selected, then the limit it is applied separately
+    max_count: Option<u64>,
+    /// When set to true it queries for most up-to-date status for each worker, default is false
+    precise: bool,
+}
+
+/// Connect to a worker and live stream its standard output, error and log channels
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct Stream {
+    worker_name: WorkerNameArg,
+    stream_args: StreamArgs,
+}
+
+/// Updates a worker
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct Update {
+    worker_name: WorkerNameArg,
+    /// Update mode - auto or manual (default is auto)
+    mode: Option<WorkerUpdateMode>,
+    /// The new version of the updated worker (default is the latest version)
+    target_version: Option<u64>,
+}
+
+/// Interrupts a running worker
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct Interrupt {
+    worker_name: WorkerNameArg,
+}
+
+/// Resume an interrupted worker
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct Resume {
+    worker_name: WorkerNameArg,
+}
+
+/// Simulates a crash on a worker for testing purposes.
+///
+/// The worker starts recovering and resuming immediately.
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct SimulateCrash {
+    worker_name: WorkerNameArg,
+}
+
+/// Queries and dumps a worker's full oplog
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct Oplog {
+    worker_name: WorkerNameArg,
+    /// Index of the first oplog entry to get. If missing, the whole oplog is returned
+    from: Option<u64>,
+    /// Lucene query to look for oplog entries. If missing, the whole oplog is returned
+    query: Option<String>,
+}
+
+/// Reverts a worker by undoing its last recorded operations
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct Revert {
+    worker_name: WorkerNameArg,
+    /// Revert by oplog index
+    last_oplog_index: Option<u64>,
+    /// Revert by number of invocations
+    number_of_invocations: Option<u64>,
+}
+
+/// Cancels an enqueued invocation if it has not started yet
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct CancelInvocation {
+    worker_name: WorkerNameArg,
+    /// Idempotency key of the invocation to be cancelled
+    idempotency_key: IdempotencyKey,
+}
+
+#[tool_router(router= tool_router_worker, vis="pub")]
+impl GolemCliMcpServer {
+    #[tool(name = "create_new_worker", description = "Create new worker")]
+    pub async fn create_new_worker(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<New>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "create_new_worker".to_owned(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = WorkerCommandHandler::new(ctx.into());
+                match tokio::task::spawn_blocking(move || {
+                    let rt = tokio::runtime::Runtime::new().unwrap();
+                    rt.block_on(async {
+                        command_new
+                            .cmd_new(req.worker_name, req.arguments, req.env)
+                            .await
+                    })
+                })
+                .await
+                {
+                    Ok(_) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+
+                        is_error: None,
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+
+    #[tool(name = "list_worker_metadata", description = "List worker metadata")]
+    pub async fn list_worker_metadata(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<List>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "list_worker_metadata".to_owned(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = WorkerCommandHandler::new(ctx.into());
+                match command_new
+                    .cmd_list(
+                        req.component_name.component_name,
+                        req.filter,
+                        None, // issue with this, need update in golem repo
+                        req.max_count,
+                        req.precise,
+                    )
+                    .await
+                {
+                    Ok(_) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+
+                        is_error: None,
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+
+    #[tool(name = "update_worker", description = "Updates a worker")]
+    pub async fn update_worker(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<Update>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "update_worker".to_owned(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = WorkerCommandHandler::new(ctx.into());
+                match command_new
+                    .cmd_update(
+                        req.worker_name,
+                        req.mode.unwrap_or(WorkerUpdateMode::Automatic),
+                        req.target_version,
+                    )
+                    .await
+                {
+                    Ok(_) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+                        is_error: None,
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+
+    #[tool(name = "get_worker_metadata", description = "Get worker metadata")]
+    pub async fn get_worker_metadata(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<Get>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "get_worker_metadata".to_owned(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = WorkerCommandHandler::new(ctx.into());
+                match command_new.cmd_get(req.worker_name).await {
+                    Ok(_) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+                        is_error: None,
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+
+    #[tool(name = "delete_worker", description = "Deletes a worker")]
+    pub async fn delete_worker(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<Delete>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "delete_worker".to_owned(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = WorkerCommandHandler::new(ctx.into());
+                match command_new.cmd_delete(req.worker_name).await {
+                    Ok(_) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+                        is_error: None,
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+
+    #[tool(
+        name = "invoke_worker",
+        description = "Invoke (or enqueue invocation for) worker"
+    )]
+    pub async fn invoke_worker(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<Invoke>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "invoke_worker".to_owned(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = WorkerCommandHandler::new(ctx.into());
+                match tokio::task::spawn_blocking(move || {
+                    let rt = tokio::runtime::Runtime::new().unwrap();
+                    rt.block_on(async {
+                        command_new
+                            .cmd_invoke(
+                                req.worker_name,
+                                &req.function_name,
+                                req.arguments,
+                                req.enqueue,
+                                req.idempotency_key,
+                                req.stream,
+                                req.stream_args,
+                            )
+                            .await
+                    })
+                })
+                .await
+                {
+                    Ok(_) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+                        is_error: None,
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+
+    #[tool(name = "resume_worker", description = "Resume an interrupted worker")]
+    pub async fn resume_worker(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<Resume>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "resume_worker".to_owned(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = WorkerCommandHandler::new(ctx.into());
+                match command_new.cmd_resume(req.worker_name).await {
+                    Ok(_) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+                        is_error: None,
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+
+    #[tool(name = "interupt_worker", description = "Interrupts a running worker")]
+    pub async fn interupt_worker(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<Interrupt>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "interupt_worker".to_owned(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = WorkerCommandHandler::new(ctx.into());
+                match command_new.cmd_interrupt(req.worker_name).await {
+                    Ok(_) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+                        is_error: None,
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+
+    #[tool(
+        name = "simulate_worker_crash",
+        description = "Simulates a crash on a worker for testing purposes. The worker starts recovering and resuming immediately."
+    )]
+    pub async fn simulate_worker_crash(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<SimulateCrash>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "simulate_worker_crash".to_owned(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = WorkerCommandHandler::new(ctx.into());
+                match command_new.cmd_simulate_crash(req.worker_name).await {
+                    Ok(_) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+                        is_error: None,
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+
+    #[tool(
+        name = "query_worker_oplog",
+        description = "Queries and dumps a worker's full oplog"
+    )]
+    pub async fn query_worker_oplog(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<Oplog>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "query_worker_oplog".to_owned(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = WorkerCommandHandler::new(ctx.into());
+                match command_new
+                    .cmd_oplog(req.worker_name, req.from, req.query)
+                    .await
+                {
+                    Ok(_) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+                        is_error: None,
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+
+    #[tool(
+        name = "stream_worker_outputs",
+        description = "Connect to a worker and live stream its standard output, error and log channels"
+    )]
+    pub async fn stream_worker_outputs(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<Stream>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "stream_worker_outputs".to_owned(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = WorkerCommandHandler::new(ctx.into());
+                match command_new
+                    .cmd_stream(req.worker_name, req.stream_args)
+                    .await
+                {
+                    Ok(_) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+                        is_error: None,
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+
+    #[tool(
+        name = "revert_worker_operations",
+        description = "Reverts a worker by undoing its last recorded operations"
+    )]
+    pub async fn revert_worker_operations(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<Revert>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "revert_worker_operations".to_owned(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = WorkerCommandHandler::new(ctx.into());
+                match command_new
+                    .cmd_revert(
+                        req.worker_name,
+                        req.last_oplog_index,
+                        req.number_of_invocations,
+                    )
+                    .await
+                {
+                    Ok(_) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+                        is_error: None,
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+
+    #[tool(
+        name = "cancel_worker_invocation",
+        description = "Cancels an enqueued invocation if it has not started yet"
+    )]
+    pub async fn cancel_worker_invocation(
+        &self,
+        client: Peer<RoleServer>,
+        Parameters(req): Parameters<CancelInvocation>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let start_local_server_yes = Arc::new(tokio::sync::RwLock::new(false));
+
+        match crate::context::Context::new(
+            GolemCliGlobalFlags::default(),
+            Some(Output::Mcp(McpClient {
+                client,
+                tool_name: "cancel_worker_invocation".to_owned(),
+            })),
+            start_local_server_yes,
+            Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
+        )
+        .await
+        {
+            Ok(ctx) => {
+                let command_new = WorkerCommandHandler::new(ctx.into());
+                match command_new
+                    .cmd_cancel_invocation(req.worker_name, req.idempotency_key)
+                    .await
+                {
+                    Ok(_) => Ok(CallToolResult {
+                        content: vec![Content::text("Success")],
+                        is_error: None,
+                    }),
+                    Err(e) => Ok(CallToolResult {
+                        content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                        is_error: Some(true),
+                    }),
+                }
+            }
+            Err(e) => Ok(CallToolResult {
+                content: vec![Content::text(strip_ansi_codes(&e.to_string()).to_string())],
+                is_error: Some(true),
+            }),
+        }
+    }
+}

--- a/golem-cli/src/command_handler/mcp_server/tools/worker.rs
+++ b/golem-cli/src/command_handler/mcp_server/tools/worker.rs
@@ -5,11 +5,11 @@ use crate::command::shared_args::{
 use crate::command::GolemCliGlobalFlags;
 use crate::command_handler::mcp_server::GolemCliMcpServer;
 use crate::command_handler::worker::WorkerCommandHandler;
-use crate::log::{McpClient, Output};
+use crate::log::{Mcp, Output};
 use crate::model::{IdempotencyKey, WorkerUpdateMode};
 use console::strip_ansi_codes;
 use rmcp::handler::server::tool::Parameters;
-use rmcp::model::{CallToolResult, Content};
+use rmcp::model::{CallToolResult, Content, Meta};
 use rmcp::{schemars, tool, tool_router, Error as CallToolError, Peer, RoleServer};
 use serde::{Deserialize, Serialize};
 use std::future::Future;
@@ -151,6 +151,7 @@ impl GolemCliMcpServer {
     #[tool(name = "create_new_worker", description = "Create new worker")]
     pub async fn create_new_worker(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<New>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -158,9 +159,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "create_new_worker".to_owned(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -200,6 +202,7 @@ impl GolemCliMcpServer {
     #[tool(name = "list_worker_metadata", description = "List worker metadata")]
     pub async fn list_worker_metadata(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<List>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -207,9 +210,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "list_worker_metadata".to_owned(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -249,6 +253,7 @@ impl GolemCliMcpServer {
     #[tool(name = "update_worker", description = "Updates a worker")]
     pub async fn update_worker(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<Update>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -256,9 +261,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "update_worker".to_owned(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
@@ -295,6 +301,7 @@ impl GolemCliMcpServer {
     #[tool(name = "get_worker_metadata", description = "Get worker metadata")]
     pub async fn get_worker_metadata(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<Get>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -302,9 +309,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "get_worker_metadata".to_owned(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
@@ -334,6 +342,7 @@ impl GolemCliMcpServer {
     #[tool(name = "delete_worker", description = "Deletes a worker")]
     pub async fn delete_worker(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<Delete>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -341,9 +350,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "delete_worker".to_owned(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
@@ -376,6 +386,7 @@ impl GolemCliMcpServer {
     )]
     pub async fn invoke_worker(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<Invoke>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -383,9 +394,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "invoke_worker".to_owned(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
@@ -432,6 +444,7 @@ impl GolemCliMcpServer {
     #[tool(name = "resume_worker", description = "Resume an interrupted worker")]
     pub async fn resume_worker(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<Resume>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -439,9 +452,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "resume_worker".to_owned(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
@@ -471,6 +485,7 @@ impl GolemCliMcpServer {
     #[tool(name = "interupt_worker", description = "Interrupts a running worker")]
     pub async fn interupt_worker(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<Interrupt>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -478,9 +493,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "interupt_worker".to_owned(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
@@ -513,6 +529,7 @@ impl GolemCliMcpServer {
     )]
     pub async fn simulate_worker_crash(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<SimulateCrash>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -520,9 +537,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "simulate_worker_crash".to_owned(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
@@ -555,6 +573,7 @@ impl GolemCliMcpServer {
     )]
     pub async fn query_worker_oplog(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<Oplog>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -562,9 +581,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "query_worker_oplog".to_owned(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
@@ -600,6 +620,7 @@ impl GolemCliMcpServer {
     )]
     pub async fn stream_worker_outputs(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<Stream>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -607,9 +628,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "stream_worker_outputs".to_owned(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
@@ -645,6 +667,7 @@ impl GolemCliMcpServer {
     )]
     pub async fn revert_worker_operations(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<Revert>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -652,9 +675,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "revert_worker_operations".to_owned(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
@@ -694,6 +718,7 @@ impl GolemCliMcpServer {
     )]
     pub async fn cancel_worker_invocation(
         &self,
+        meta: Meta,
         client: Peer<RoleServer>,
         Parameters(req): Parameters<CancelInvocation>,
     ) -> Result<CallToolResult, CallToolError> {
@@ -701,9 +726,10 @@ impl GolemCliMcpServer {
 
         match crate::context::Context::new(
             GolemCliGlobalFlags::default(),
-            Some(Output::Mcp(McpClient {
+            Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "cancel_worker_invocation".to_owned(),
+                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now

--- a/golem-cli/src/command_handler/mcp_server/tools/worker.rs
+++ b/golem-cli/src/command_handler/mcp_server/tools/worker.rs
@@ -5,7 +5,7 @@ use crate::command::shared_args::{
 use crate::command::GolemCliGlobalFlags;
 use crate::command_handler::mcp_server::GolemCliMcpServer;
 use crate::command_handler::worker::WorkerCommandHandler;
-use crate::log::{Mcp, Output};
+use crate::log::{get_mcp_tool_output, Mcp, Output};
 use crate::model::{IdempotencyKey, WorkerUpdateMode};
 use console::strip_ansi_codes;
 use rmcp::handler::server::tool::Parameters;
@@ -162,7 +162,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "create_new_worker".to_owned(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -182,7 +182,7 @@ impl GolemCliMcpServer {
                 .await
                 {
                     Ok(_) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
 
                         is_error: None,
                     }),
@@ -213,7 +213,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "list_worker_metadata".to_owned(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now, can we provide a seperate tool to start the golem server
@@ -233,7 +233,7 @@ impl GolemCliMcpServer {
                     .await
                 {
                     Ok(_) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
 
                         is_error: None,
                     }),
@@ -264,7 +264,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "update_worker".to_owned(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
@@ -282,7 +282,7 @@ impl GolemCliMcpServer {
                     .await
                 {
                     Ok(_) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
                         is_error: None,
                     }),
                     Err(e) => Ok(CallToolResult {
@@ -312,7 +312,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "get_worker_metadata".to_owned(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
@@ -323,7 +323,7 @@ impl GolemCliMcpServer {
                 let command_new = WorkerCommandHandler::new(ctx.into());
                 match command_new.cmd_get(req.worker_name).await {
                     Ok(_) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
                         is_error: None,
                     }),
                     Err(e) => Ok(CallToolResult {
@@ -353,7 +353,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "delete_worker".to_owned(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
@@ -364,7 +364,7 @@ impl GolemCliMcpServer {
                 let command_new = WorkerCommandHandler::new(ctx.into());
                 match command_new.cmd_delete(req.worker_name).await {
                     Ok(_) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
                         is_error: None,
                     }),
                     Err(e) => Ok(CallToolResult {
@@ -397,7 +397,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "invoke_worker".to_owned(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
@@ -425,7 +425,7 @@ impl GolemCliMcpServer {
                 .await
                 {
                     Ok(_) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
                         is_error: None,
                     }),
                     Err(e) => Ok(CallToolResult {
@@ -455,7 +455,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "resume_worker".to_owned(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
@@ -466,7 +466,7 @@ impl GolemCliMcpServer {
                 let command_new = WorkerCommandHandler::new(ctx.into());
                 match command_new.cmd_resume(req.worker_name).await {
                     Ok(_) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
                         is_error: None,
                     }),
                     Err(e) => Ok(CallToolResult {
@@ -496,7 +496,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "interupt_worker".to_owned(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
@@ -507,7 +507,7 @@ impl GolemCliMcpServer {
                 let command_new = WorkerCommandHandler::new(ctx.into());
                 match command_new.cmd_interrupt(req.worker_name).await {
                     Ok(_) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
                         is_error: None,
                     }),
                     Err(e) => Ok(CallToolResult {
@@ -540,7 +540,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "simulate_worker_crash".to_owned(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
@@ -551,7 +551,7 @@ impl GolemCliMcpServer {
                 let command_new = WorkerCommandHandler::new(ctx.into());
                 match command_new.cmd_simulate_crash(req.worker_name).await {
                     Ok(_) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
                         is_error: None,
                     }),
                     Err(e) => Ok(CallToolResult {
@@ -584,7 +584,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "query_worker_oplog".to_owned(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
@@ -598,7 +598,7 @@ impl GolemCliMcpServer {
                     .await
                 {
                     Ok(_) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
                         is_error: None,
                     }),
                     Err(e) => Ok(CallToolResult {
@@ -631,7 +631,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "stream_worker_outputs".to_owned(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
@@ -645,7 +645,7 @@ impl GolemCliMcpServer {
                     .await
                 {
                     Ok(_) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
                         is_error: None,
                     }),
                     Err(e) => Ok(CallToolResult {
@@ -678,7 +678,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "revert_worker_operations".to_owned(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
@@ -696,7 +696,7 @@ impl GolemCliMcpServer {
                     .await
                 {
                     Ok(_) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
                         is_error: None,
                     }),
                     Err(e) => Ok(CallToolResult {
@@ -729,7 +729,7 @@ impl GolemCliMcpServer {
             Some(Output::Mcp(Mcp {
                 client,
                 tool_name: "cancel_worker_invocation".to_owned(),
-                progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
+                // progress_token: meta.get_progress_token().ok_or(CallToolError::invalid_params("Progress Token is required to use this tool", None))?
             })),
             start_local_server_yes,
             Box::new(|| Box::pin(async { Ok(()) })), // dummy, not starting anything for now
@@ -743,7 +743,7 @@ impl GolemCliMcpServer {
                     .await
                 {
                     Ok(_) => Ok(CallToolResult {
-                        content: vec![Content::text("Success")],
+                        content: get_mcp_tool_output().into_iter().map(Content::text).collect(),
                         is_error: None,
                     }),
                     Err(e) => Ok(CallToolResult {

--- a/golem-cli/src/command_handler/plugin.rs
+++ b/golem-cli/src/command_handler/plugin.rs
@@ -62,7 +62,7 @@ impl PluginCommandHandler {
         }
     }
 
-    async fn cmd_list(&self, scope: PluginScopeArgs) -> anyhow::Result<()> {
+    pub async fn cmd_list(&self, scope: PluginScopeArgs) -> anyhow::Result<()> {
         let (scope_project, scope_component_id) = self.resolve_scope(&scope).await?;
 
         let clients = self.ctx.golem_clients().await?;
@@ -87,13 +87,13 @@ impl PluginCommandHandler {
         Ok(())
     }
 
-    async fn cmd_get(&self, plugin_name: String, version: String) -> anyhow::Result<()> {
+    pub async fn cmd_get(&self, plugin_name: String, version: String) -> anyhow::Result<()> {
         let plugin_definition = self.get(&plugin_name, &version).await?;
         self.ctx.log_handler().log_view(&plugin_definition);
         Ok(())
     }
 
-    async fn cmd_register(
+    pub async fn cmd_register(
         &self,
         scope: PluginScopeArgs,
         manifest: PathBufOrStdin,
@@ -277,7 +277,7 @@ impl PluginCommandHandler {
         Ok(())
     }
 
-    async fn cmd_unregister(&self, plugin_name: String, version: String) -> anyhow::Result<()> {
+    pub async fn cmd_unregister(&self, plugin_name: String, version: String) -> anyhow::Result<()> {
         let clients = self.ctx.golem_clients().await?;
 
         clients

--- a/golem-cli/src/command_handler/profile/config.rs
+++ b/golem-cli/src/command_handler/profile/config.rs
@@ -43,7 +43,7 @@ impl ProfileConfigCommandHandler {
         }
     }
 
-    fn cmd_set_format(&self, profile_name: ProfileName, format: Format) -> anyhow::Result<()> {
+    pub fn cmd_set_format(&self, profile_name: ProfileName, format: Format) -> anyhow::Result<()> {
         match Config::get_profile(self.ctx.config_dir(), &profile_name)? {
             Some(mut profile) => {
                 profile.profile.config.default_format = format;

--- a/golem-cli/src/command_handler/profile/mod.rs
+++ b/golem-cli/src/command_handler/profile/mod.rs
@@ -76,7 +76,7 @@ impl ProfileCommandHandler {
         }
     }
 
-    fn cmd_new(
+    pub fn cmd_new(
         &self,
         name: Option<ProfileName>,
         set_active: bool,
@@ -135,7 +135,7 @@ impl ProfileCommandHandler {
         Ok(())
     }
 
-    fn cmd_list(&self) -> anyhow::Result<()> {
+    pub fn cmd_list(&self) -> anyhow::Result<()> {
         let config = Config::from_dir(self.ctx.config_dir())?;
         let default_profile_name = config.default_profile_name();
 
@@ -153,12 +153,12 @@ impl ProfileCommandHandler {
         Ok(())
     }
 
-    fn cmd_switch(&self, profile_name: ProfileName) -> anyhow::Result<()> {
+    pub fn cmd_switch(&self, profile_name: ProfileName) -> anyhow::Result<()> {
         Config::set_active_profile_name(profile_name, self.ctx.config_dir())?;
         Ok(())
     }
 
-    fn cmd_get(&self, profile_name: Option<ProfileName>) -> anyhow::Result<()> {
+    pub fn cmd_get(&self, profile_name: Option<ProfileName>) -> anyhow::Result<()> {
         let default_profile = Config::get_default_profile(self.ctx.config_dir())?;
         let default_profile_name = default_profile.name.clone();
 
@@ -185,7 +185,7 @@ impl ProfileCommandHandler {
         Ok(())
     }
 
-    fn cmd_delete(&self, profile_name: ProfileName) -> anyhow::Result<()> {
+    pub fn cmd_delete(&self, profile_name: ProfileName) -> anyhow::Result<()> {
         if profile_name.is_builtin() {
             log_error(format!(
                 "Cannot delete builtin profile: {}",

--- a/golem-cli/src/command_handler/worker/mod.rs
+++ b/golem-cli/src/command_handler/worker/mod.rs
@@ -164,7 +164,7 @@ impl WorkerCommandHandler {
         }
     }
 
-    async fn cmd_new(
+    pub async fn cmd_new(
         &self,
         worker_name: WorkerNameArg,
         arguments: Vec<NewWorkerArgument>,
@@ -225,7 +225,7 @@ impl WorkerCommandHandler {
         Ok(())
     }
 
-    async fn cmd_invoke(
+    pub async fn cmd_invoke(
         &self,
         worker_name: WorkerNameArg,
         function_name: &WorkerFunctionName,
@@ -384,7 +384,7 @@ impl WorkerCommandHandler {
         Ok(())
     }
 
-    async fn cmd_stream(
+    pub async fn cmd_stream(
         &self,
         worker_name: WorkerNameArg,
         stream_args: StreamArgs,
@@ -417,7 +417,7 @@ impl WorkerCommandHandler {
         Ok(())
     }
 
-    async fn cmd_simulate_crash(&self, worker_name: WorkerNameArg) -> anyhow::Result<()> {
+    pub async fn cmd_simulate_crash(&self, worker_name: WorkerNameArg) -> anyhow::Result<()> {
         self.ctx.silence_app_context_init().await;
         let worker_name_match = self.match_worker_name(worker_name.worker_name).await?;
         let (component, worker_name) = self
@@ -446,7 +446,7 @@ impl WorkerCommandHandler {
         Ok(())
     }
 
-    async fn cmd_oplog(
+    pub async fn cmd_oplog(
         &self,
         worker_name: WorkerNameArg,
         from: Option<u64>,
@@ -500,7 +500,7 @@ impl WorkerCommandHandler {
         Ok(())
     }
 
-    async fn cmd_revert(
+    pub async fn cmd_revert(
         &self,
         worker_name: WorkerNameArg,
         last_oplog_index: Option<u64>,
@@ -563,7 +563,7 @@ impl WorkerCommandHandler {
         Ok(())
     }
 
-    async fn cmd_cancel_invocation(
+    pub async fn cmd_cancel_invocation(
         &self,
         worker_name: WorkerNameArg,
         idempotency_key: IdempotencyKey,
@@ -606,7 +606,7 @@ impl WorkerCommandHandler {
         Ok(())
     }
 
-    async fn cmd_list(
+    pub async fn cmd_list(
         &self,
         component_name: Option<ComponentName>,
         filters: Vec<String>,
@@ -683,7 +683,7 @@ impl WorkerCommandHandler {
         Ok(())
     }
 
-    async fn cmd_interrupt(&self, worker_name: WorkerNameArg) -> anyhow::Result<()> {
+    pub async fn cmd_interrupt(&self, worker_name: WorkerNameArg) -> anyhow::Result<()> {
         self.ctx.silence_app_context_init().await;
         let worker_name_match = self.match_worker_name(worker_name.worker_name).await?;
         let (component, worker_name) = self
@@ -706,7 +706,7 @@ impl WorkerCommandHandler {
         Ok(())
     }
 
-    async fn cmd_resume(&self, worker_name: WorkerNameArg) -> anyhow::Result<()> {
+    pub async fn cmd_resume(&self, worker_name: WorkerNameArg) -> anyhow::Result<()> {
         self.ctx.silence_app_context_init().await;
         let worker_name_match = self.match_worker_name(worker_name.worker_name).await?;
         let (component, worker_name) = self
@@ -728,7 +728,7 @@ impl WorkerCommandHandler {
         Ok(())
     }
 
-    async fn cmd_update(
+    pub async fn cmd_update(
         &self,
         worker_name: WorkerNameArg,
         mode: WorkerUpdateMode,
@@ -779,7 +779,7 @@ impl WorkerCommandHandler {
         Ok(())
     }
 
-    async fn cmd_get(&self, worker_name: WorkerNameArg) -> anyhow::Result<()> {
+    pub async fn cmd_get(&self, worker_name: WorkerNameArg) -> anyhow::Result<()> {
         self.ctx.silence_app_context_init().await;
         let worker_name_match = self.match_worker_name(worker_name.worker_name).await?;
         let (component, worker_name) = self
@@ -808,7 +808,7 @@ impl WorkerCommandHandler {
         Ok(())
     }
 
-    async fn cmd_delete(&self, worker_name: WorkerNameArg) -> anyhow::Result<()> {
+    pub async fn cmd_delete(&self, worker_name: WorkerNameArg) -> anyhow::Result<()> {
         self.ctx.silence_app_context_init().await;
         let worker_name_match = self.match_worker_name(worker_name.worker_name).await?;
         let (component, worker_name) = self

--- a/golem-cli/src/config.rs
+++ b/golem-cli/src/config.rs
@@ -17,6 +17,7 @@ use anyhow::{anyhow, bail, Context};
 use chrono::{DateTime, Utc};
 use golem_client::model::TokenSecret;
 use itertools::Itertools;
+use rmcp::schemars;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fmt::Debug;
@@ -44,7 +45,9 @@ pub struct Config {
     pub default_profile: Option<ProfileName>,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
+#[derive(
+    Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize, schemars::JsonSchema,
+)]
 pub struct ProfileName(pub String);
 
 impl ProfileName {

--- a/golem-cli/src/log.rs
+++ b/golem-cli/src/log.rs
@@ -14,6 +14,9 @@
 
 use crate::fs::{OverwriteSafeAction, OverwriteSafeActionPlan, PathExtra};
 use colored::{ColoredString, Colorize};
+use console::strip_ansi_codes;
+use rmcp::model::LoggingMessageNotificationParam;
+use rmcp::{Peer, RoleServer};
 use std::borrow::Cow;
 use std::path::{Path, PathBuf};
 use std::sync::{LazyLock, OnceLock, RwLock};
@@ -29,12 +32,25 @@ fn terminal_width() -> Option<usize> {
     *TERMINAL_WIDTH.get_or_init(|| terminal_size().map(|(width, _)| width.0 as usize))
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub enum Output {
     Stdout,
     Stderr,
     None,
     TracingDebug,
+    Mcp(McpClient),
+}
+
+impl Output {
+    fn is_mcp(&self) -> bool {
+        matches!(self, Output::Mcp(_))
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct McpClient {
+    pub client: Peer<RoleServer>,
+    pub tool_name: String,
 }
 
 struct LogState {
@@ -117,15 +133,20 @@ pub struct LogOutput {
 
 impl LogOutput {
     pub fn new(output: Output) -> Self {
-        let prev_output = LOG_STATE.read().unwrap().output;
+        let prev_output = &LOG_STATE.read().unwrap().output.clone();
         LOG_STATE.write().unwrap().set_output(output);
-        Self { prev_output }
+        Self {
+            prev_output: prev_output.clone(),
+        }
     }
 }
 
 impl Drop for LogOutput {
     fn drop(&mut self) {
-        LOG_STATE.write().unwrap().set_output(self.prev_output);
+        LOG_STATE
+            .write()
+            .unwrap()
+            .set_output(self.prev_output.clone());
     }
 }
 
@@ -159,37 +180,72 @@ pub fn logln<T: AsRef<str>>(message: T) {
 }
 
 pub fn logln_internal(message: &str) {
+    // Acquire read lock once
     let state = LOG_STATE.read().unwrap();
+    let width = state.max_width;
+    let indent = state.calculated_indent.clone();
+    let output = state.output.clone();
 
-    let lines = match state.max_width {
-        Some(width) if width <= message.len() && !message.contains("\n") => {
+    drop(state); // Release read lock before logging
+
+    // Wrap lines if needed
+    let lines: Vec<Cow<'_, str>> = if !output.is_mcp() {
+        process_lines(message, width)
+    } else {
+        vec![Cow::from(process_lines(message, width).concat())]
+    };
+
+    for line in lines {
+        match &output {
+            Output::Stdout => println!("{}{}", indent, line),
+            Output::Stderr => eprintln!("{}{}", indent, line),
+            Output::None => {}
+            Output::TracingDebug => debug!("{}{}", indent, line),
+            Output::Mcp(mcp_client) => {
+                notify_log_to_mcp_client(message, &indent, line, mcp_client);
+            }
+        }
+    }
+}
+
+fn process_lines(message: &str, width: Option<usize>) -> Vec<Cow<'_, str>> {
+    match width {
+        Some(w) if w > 0 && message.len() > w && !message.contains('\n') => {
             textwrap::wrap(
                 message,
-                textwrap::Options::new(width)
+                textwrap::Options::new(w)
                     // deliberately 5 spaces, to makes this indent different from normal ones
                     .subsequent_indent("     ")
                     .word_splitter(WordSplitter::NoHyphenation),
             )
         }
-        _ => {
-            vec![Cow::from(message)]
-        }
-    };
-
-    for line in lines {
-        match state.output {
-            Output::Stdout => {
-                println!("{}{}", state.calculated_indent, line)
-            }
-            Output::Stderr => {
-                eprintln!("{}{}", state.calculated_indent, line)
-            }
-            Output::None => {}
-            Output::TracingDebug => {
-                debug!("{}{}", state.calculated_indent, line);
-            }
-        }
+        _ => vec![Cow::from(message)],
     }
+}
+
+fn notify_log_to_mcp_client(
+    message: &str,
+    indent: &String,
+    line: Cow<'_, str>,
+    mcp_client: &McpClient,
+) {
+    let data: String = format!("{}{}", indent, line).clone();
+    let _message_owned = message.to_string();
+    tokio::spawn({
+        let client = mcp_client.client.clone();
+        let tool_name = mcp_client.tool_name.clone();
+        async move {
+            let plain_data = strip_ansi_codes(&data).into_owned();
+
+            let _ = client
+                .notify_logging_message(LoggingMessageNotificationParam {
+                    level: rmcp::model::LoggingLevel::Info,
+                    logger: Some(format!("golem-cli mcp server tool: {}", tool_name)),
+                    data: plain_data.into(),
+                })
+                .await;
+        }
+    });
 }
 
 pub fn log_skipping_up_to_date<T: AsRef<str>>(subject: T) {

--- a/golem-cli/src/log.rs
+++ b/golem-cli/src/log.rs
@@ -27,7 +27,9 @@ use tracing::debug;
 static LOG_STATE: LazyLock<RwLock<LogState>> = LazyLock::new(RwLock::default);
 static TERMINAL_WIDTH: OnceLock<Option<usize>> = OnceLock::new();
 static WRAP_PADDING: usize = 2;
-static PROGRESS_COUNTER: LazyLock<RwLock<u32>> = LazyLock::new(|| RwLock::new(0));
+// static PROGRESS_COUNTER: LazyLock<RwLock<u32>> = LazyLock::new(|| RwLock::new(0));
+static TOOL_OUTPUT: LazyLock<RwLock<Vec<String>>> = LazyLock::new(RwLock::default);
+
 
 fn terminal_width() -> Option<usize> {
     *TERMINAL_WIDTH.get_or_init(|| terminal_size().map(|(width, _)| width.0 as usize))
@@ -52,7 +54,7 @@ impl Output {
 pub struct Mcp {
     pub client: Peer<RoleServer>,
     pub tool_name: String,
-    pub progress_token: ProgressToken
+    // pub progress_token: ProgressToken
 }
 
 struct LogState {
@@ -157,6 +159,10 @@ pub fn set_log_output(output: Output) {
     LOG_STATE.write().unwrap().set_output(output);
 }
 
+pub fn get_log_output() -> Output {
+    LOG_STATE.read().unwrap().output.clone()
+}
+
 pub fn log_action<T: AsRef<str>>(action: &str, subject: T) {
     logln_internal(&format!(
         "{} {}",
@@ -203,8 +209,9 @@ pub fn logln_internal(message: &str) {
             Output::Stderr => eprintln!("{}{}", indent, line),
             Output::None => {}
             Output::TracingDebug => debug!("{}{}", indent, line),
-            Output::Mcp(mcp) => {
-                notify_log_to_mcp_client(&indent, line, mcp);
+            Output::Mcp(_mcp) => {
+                store_mcp_tool_output(&indent, line)
+                // notify_log_to_mcp_client(&indent, line, mcp);
             }
         }
     }
@@ -225,30 +232,45 @@ fn process_lines(message: &str, width: Option<usize>) -> Vec<Cow<'_, str>> {
     }
 }
 
-fn notify_log_to_mcp_client(
+// fn notify_log_to_mcp_client(
+//     indent: &str,
+//     line: Cow<'_, str>,
+//     mcp: &Mcp,
+// ) {
+//     let data: String = format!("{}{}", indent, line).clone();
+//     let progress = *PROGRESS_COUNTER.read().unwrap() as u32;
+//     tokio::spawn({
+//         let client = mcp.client.clone();
+//         let progress_token = mcp.progress_token.clone();
+//         let progress = progress;
+//         async move {
+//             let plain_data = strip_ansi_codes(&data).into_owned();
+
+//             let _ = client.notify_progress(ProgressNotificationParam {
+//                     progress_token,
+//                     progress,
+//                     message: plain_data.into(),
+//                     total: None,
+//                 })
+//                 .await;
+//             *PROGRESS_COUNTER.write().unwrap() = progress + 1;
+//         }
+//     });
+// }
+
+pub fn store_mcp_tool_output(
     indent: &str,
     line: Cow<'_, str>,
-    mcp: &Mcp,
 ) {
     let data: String = format!("{}{}", indent, line).clone();
-    let progress = *PROGRESS_COUNTER.read().unwrap() as u32;
-    tokio::spawn({
-        let client = mcp.client.clone();
-        let progress_token = mcp.progress_token.clone();
-        let progress = progress;
-        async move {
-            let plain_data = strip_ansi_codes(&data).into_owned();
+    (*TOOL_OUTPUT.write().unwrap()).push(data)
+}
 
-            let _ = client.notify_progress(ProgressNotificationParam {
-                    progress_token,
-                    progress,
-                    message: plain_data.into(),
-                    total: None,
-                })
-                .await;
-            *PROGRESS_COUNTER.write().unwrap() = progress + 1;
-        }
-    });
+pub fn get_mcp_tool_output() -> Vec<String> {
+    let output = TOOL_OUTPUT.read().unwrap().to_vec().join("\n");
+    (*TOOL_OUTPUT.write().unwrap()).clear();
+    
+    vec![output]
 }
 
 pub fn log_skipping_up_to_date<T: AsRef<str>>(subject: T) {

--- a/golem-cli/src/log.rs
+++ b/golem-cli/src/log.rs
@@ -15,7 +15,7 @@
 use crate::fs::{OverwriteSafeAction, OverwriteSafeActionPlan, PathExtra};
 use colored::{ColoredString, Colorize};
 use console::strip_ansi_codes;
-use rmcp::model::LoggingMessageNotificationParam;
+use rmcp::model::{ProgressNotificationParam, ProgressToken};
 use rmcp::{Peer, RoleServer};
 use std::borrow::Cow;
 use std::path::{Path, PathBuf};
@@ -27,6 +27,7 @@ use tracing::debug;
 static LOG_STATE: LazyLock<RwLock<LogState>> = LazyLock::new(RwLock::default);
 static TERMINAL_WIDTH: OnceLock<Option<usize>> = OnceLock::new();
 static WRAP_PADDING: usize = 2;
+static PROGRESS_COUNTER: LazyLock<RwLock<u32>> = LazyLock::new(|| RwLock::new(0));
 
 fn terminal_width() -> Option<usize> {
     *TERMINAL_WIDTH.get_or_init(|| terminal_size().map(|(width, _)| width.0 as usize))
@@ -38,7 +39,7 @@ pub enum Output {
     Stderr,
     None,
     TracingDebug,
-    Mcp(McpClient),
+    Mcp(Mcp),
 }
 
 impl Output {
@@ -48,9 +49,10 @@ impl Output {
 }
 
 #[derive(Debug, Clone)]
-pub struct McpClient {
+pub struct Mcp {
     pub client: Peer<RoleServer>,
     pub tool_name: String,
+    pub progress_token: ProgressToken
 }
 
 struct LogState {
@@ -201,8 +203,8 @@ pub fn logln_internal(message: &str) {
             Output::Stderr => eprintln!("{}{}", indent, line),
             Output::None => {}
             Output::TracingDebug => debug!("{}{}", indent, line),
-            Output::Mcp(mcp_client) => {
-                notify_log_to_mcp_client(message, &indent, line, mcp_client);
+            Output::Mcp(mcp) => {
+                notify_log_to_mcp_client(&indent, line, mcp);
             }
         }
     }
@@ -224,26 +226,27 @@ fn process_lines(message: &str, width: Option<usize>) -> Vec<Cow<'_, str>> {
 }
 
 fn notify_log_to_mcp_client(
-    message: &str,
-    indent: &String,
+    indent: &str,
     line: Cow<'_, str>,
-    mcp_client: &McpClient,
+    mcp: &Mcp,
 ) {
     let data: String = format!("{}{}", indent, line).clone();
-    let _message_owned = message.to_string();
+    let progress = *PROGRESS_COUNTER.read().unwrap() as u32;
     tokio::spawn({
-        let client = mcp_client.client.clone();
-        let tool_name = mcp_client.tool_name.clone();
+        let client = mcp.client.clone();
+        let progress_token = mcp.progress_token.clone();
+        let progress = progress;
         async move {
             let plain_data = strip_ansi_codes(&data).into_owned();
 
-            let _ = client
-                .notify_logging_message(LoggingMessageNotificationParam {
-                    level: rmcp::model::LoggingLevel::Info,
-                    logger: Some(format!("golem-cli mcp server tool: {}", tool_name)),
-                    data: plain_data.into(),
+            let _ = client.notify_progress(ProgressNotificationParam {
+                    progress_token,
+                    progress,
+                    message: plain_data.into(),
+                    total: None,
                 })
                 .await;
+            *PROGRESS_COUNTER.write().unwrap() = progress + 1;
         }
     });
 }

--- a/golem-cli/src/model/api.rs
+++ b/golem-cli/src/model/api.rs
@@ -15,6 +15,7 @@
 use anyhow::bail;
 use chrono::{DateTime, Utc};
 use golem_client::model::{ApiDefinitionInfo, ApiSite, MethodPattern, Provider};
+use rmcp::schemars;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
 use std::str::FromStr;
@@ -26,7 +27,7 @@ pub enum HttpApiDeployMode {
     Matching,
 }
 
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize, schemars::JsonSchema)]
 pub enum IdentityProviderType {
     Google,
     Facebook,
@@ -103,7 +104,7 @@ impl FromStr for ApiDefinitionIdWithVersion {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct ApiDefinitionId(pub String);
 
 impl Display for ApiDefinitionId {
@@ -124,7 +125,7 @@ impl From<String> for ApiDefinitionId {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct ApiDefinitionVersion(pub String);
 
 impl Display for ApiDefinitionVersion {

--- a/golem-cli/src/model/app.rs
+++ b/golem-cli/src/model/app.rs
@@ -10,6 +10,7 @@ use crate::wasm_rpc_stubgen::naming;
 use crate::wasm_rpc_stubgen::naming::wit::package_dep_dir_name_from_parser;
 use crate::wasm_rpc_stubgen::stub::RustDependencyOverride;
 use golem_common::model::{ComponentFilePathWithPermissions, ComponentFilePermissions};
+use rmcp::schemars;
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
@@ -177,7 +178,18 @@ pub struct ComponentStubInterfaces {
     pub exported_interfaces_per_stub_resource: BTreeMap<String, String>,
 }
 
-#[derive(clap::ValueEnum, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(
+    clap::ValueEnum,
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    Serialize,
+    Deserialize,
+    schemars::JsonSchema,
+)]
 #[clap(rename_all = "kebab_case")]
 pub enum AppBuildStep {
     GenRpc,
@@ -213,7 +225,9 @@ impl From<&str> for AppComponentName {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(
+    Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, schemars::JsonSchema,
+)]
 pub struct HttpApiDefinitionName(String);
 
 impl HttpApiDefinitionName {
@@ -363,7 +377,19 @@ impl<T: Default> Default for WithSource<T> {
     }
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Default, EnumIter)]
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    Hash,
+    Default,
+    EnumIter,
+    Serialize,
+    Deserialize,
+    schemars::JsonSchema,
+)]
 pub enum DependencyType {
     #[default]
     /// Dynamic ("stubless") wasm-rpc

--- a/golem-cli/src/model/mod.rs
+++ b/golem-cli/src/model/mod.rs
@@ -42,6 +42,7 @@ use golem_common::model::trim_date::TrimDateTime;
 use golem_templates::model::{
     GuestLanguage, GuestLanguageTier, PackageName, Template, TemplateName,
 };
+use rmcp::schemars;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::{BTreeMap, HashMap};
@@ -60,7 +61,18 @@ use uuid::Uuid;
 // NOTE: using aliases for lower-case support in manifest, as global configs are using the
 //       PascalCase versions historically, should be cleared up (migrated), if we touch the global
 //       CLI config
-#[derive(Copy, Clone, PartialEq, Eq, Debug, EnumIter, Serialize, Deserialize, Default)]
+#[derive(
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    Debug,
+    EnumIter,
+    Serialize,
+    Deserialize,
+    schemars::JsonSchema,
+    Default,
+)]
 pub enum Format {
     #[serde(alias = "json")]
     Json,
@@ -105,7 +117,7 @@ pub trait HasFormatConfig {
     fn format(&self) -> Option<Format>;
 }
 
-#[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct ProjectName(pub String);
 
 impl From<&str> for ProjectName {
@@ -120,7 +132,7 @@ impl From<String> for ProjectName {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize, schemars::JsonSchema)]
 pub enum ProjectReference {
     JustName(ProjectName),
     WithAccount {
@@ -158,7 +170,9 @@ impl Display for ProjectReference {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Debug, Serialize, Deserialize)]
+#[derive(
+    Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Debug, Serialize, Deserialize, schemars::JsonSchema,
+)]
 pub struct ComponentName(pub String);
 
 impl From<&str> for ComponentName {
@@ -179,7 +193,7 @@ impl Display for ComponentName {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct WorkerName(pub String);
 
 impl From<&str> for WorkerName {
@@ -217,7 +231,7 @@ impl From<u64> for ComponentVersionSelection<'_> {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct IdempotencyKey(pub String);
 
 impl Default for IdempotencyKey {
@@ -293,7 +307,7 @@ impl TemplateDescription {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize, schemars::JsonSchema)]
 pub enum PathBufOrStdin {
     Path(PathBuf),
     Stdin,
@@ -334,10 +348,14 @@ impl FromStr for PathBufOrStdin {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Serialize, Deserialize, schemars::JsonSchema)]
 pub enum WorkerUpdateMode {
     Automatic,
     Manual,
+}
+
+pub fn default_worker_update_mode() -> WorkerUpdateMode {
+    WorkerUpdateMode::Automatic
 }
 
 impl Display for WorkerUpdateMode {
@@ -604,7 +622,7 @@ pub struct SelectedComponents {
     pub component_names: Vec<ComponentName>,
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Serialize, Deserialize)]
 pub struct TokenId(pub Uuid);
 
 impl FromStr for TokenId {
@@ -615,7 +633,7 @@ impl FromStr for TokenId {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Serialize, Deserialize)]
 pub struct ProjectPolicyId(pub Uuid);
 
 impl FromStr for ProjectPolicyId {
@@ -626,7 +644,9 @@ impl FromStr for ProjectPolicyId {
     }
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, Debug, EnumIter, Serialize, Deserialize)]
+#[derive(
+    Copy, Clone, PartialEq, Eq, Debug, EnumIter, Serialize, Deserialize, schemars::JsonSchema,
+)]
 pub enum Role {
     Admin,
     MarketingAdmin,
@@ -679,7 +699,9 @@ impl From<golem_client::model::Role> for Role {
     }
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, Debug, EnumIter)]
+#[derive(
+    Copy, Clone, PartialEq, Eq, Debug, EnumIter, Serialize, Deserialize, schemars::JsonSchema,
+)]
 pub enum ProjectPermission {
     ViewComponent,
     CreateComponent,
@@ -876,7 +898,7 @@ pub struct NewInteractiveApp {
     pub templated_component_names: Vec<(ComponentTemplateName, PackageName)>,
 }
 
-#[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct AccountId(pub String);
 
 impl From<String> for AccountId {

--- a/golem-templates/Cargo.toml
+++ b/golem-templates/Cargo.toml
@@ -24,6 +24,8 @@ include_dir = { workspace = true }
 itertools = { workspace = true }
 nanoid = { workspace = true }
 regex = { workspace = true }
+rmcp = { workspace= true }
+schemars = { workspace= true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 strum = { workspace = true }

--- a/golem-templates/src/model.rs
+++ b/golem-templates/src/model.rs
@@ -14,6 +14,7 @@
 
 use fancy_regex::{Match, Regex};
 use heck::{ToLowerCamelCase, ToPascalCase, ToSnakeCase, ToTitleCase};
+use rmcp::schemars;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::fmt::Formatter;
@@ -114,7 +115,18 @@ impl TemplateKind {
 }
 
 #[derive(
-    Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, EnumIter, Serialize, Deserialize,
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    EnumIter,
+    Serialize,
+    Deserialize,
+    schemars::JsonSchema,
 )]
 pub enum GuestLanguage {
     C,
@@ -126,6 +138,10 @@ pub enum GuestLanguage {
     Zig,
     ScalaJs,
     MoonBit,
+}
+
+pub fn default_guest_language() -> GuestLanguage {
+    GuestLanguage::Rust
 }
 
 impl GuestLanguage {
@@ -255,7 +271,9 @@ impl FromStr for GuestLanguageTier {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(
+    Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, schemars::JsonSchema,
+)]
 pub struct PackageName((String, String));
 
 impl PackageName {


### PR DESCRIPTION
---

**Title:** Golem CLI: MCP Server mode (Resolves #275)

For algora:
/claim #275

**Body:**

Hey team,

This PR addresses **Issue #275**, which outlines the need for the Golem CLI to expose its capabilities programmatically via an MCP (Model Context Protocol) server. The core goal is to enable seamless integration with AI agents like Claude Code, Gemini cli, allowing them to interact with the CLI's functionality as structured "tools" and "resources."



*   **New `golem-cli mcp-server` Command:**
    *   Introduces a new command-line interface for the Golem CLI to run in a "MCP" mode, launching an MCP server.
    *   This server will listen on a specified port, use specified transport (e.g., `golem-cli mcp-server run --port <PORT> --transport <Sse|StreamableHttp>`), exposing the CLI's capabilities.
    * For more details on how to use tun this command `golem-cli mcp-server`

*   **Commands as MCP Tools:**
    *   All relevant Golem CLI commands are now exposed as distinct MCP "tools."
    *   Each tool comes with precise JSON Schema definitions for its inputs and expected structured outputs.

*   **Manifest Files as MCP Resources:**
    *   The MCP server exposes manifest files (e.g., `golem.yaml`) in the current, ancestor, and children directories as discoverable "resources." This allows external agents to understand the project context.

*   **Enabling AI Agent Integration:**
    *   This foundational work makes it possible for agents like Claude Code to programmatically invoke Golem CLI operations, achieving anything the CLI can do, but with structured communication.

*   **Leveraging `rmcp`:**
    *   The implementation utilizes the `rmcp` Rust library, for building the MCP server and defining tools. It recently has a release and its official rust sdk from @modelcontextprotocol

**Important notes:**
*   Incremental output is supported by rmcp lib and i have added its support in prev commits, but currently claude code or gemini cli dont support incremental output. (Need a progress in MCP client ecosystem. MCP is relatively new).

*   This initial setup is designed for **single-user, local machine environments**. Didnt tested for any effects if used in async manner.
*   Some commands which are security sensitive that deals with token and passwords are disabled and not exposed as tools.
*   As this mcp mode is used with ai, proper security vetting need to be done like input validation and others before releasing.

**Whats Pending:**
*   Other than manual testing(which tried with gemini cli, i say its ok(starting is difficult, as we use gemini cli tends to learn). We can also improve on tool descriptions to make it even good. Let me know how its in Calude Code.
*   I currently have no clear idea how to make out test cases and run it automatically. Advise needed.

Thank you very much for reading.
---