### PR TITLE
Precise flag for worker status rendering

### DIFF
--- a/golem-cli/src/command_handler/worker/mod.rs
+++ b/golem-cli/src/command_handler/worker/mod.rs
@@ -808,7 +808,7 @@ impl WorkerCommandHandler {
 
         self.ctx
             .log_handler()
-            .log_view(&WorkerGetView::from(result));
+            .log_view(&WorkerGetView::from_metadata(result, true));
 
         Ok(())
     }


### PR DESCRIPTION
Resolves #103 

This implements a better rendering of "non precise worker metadata", although after implementing it I realized this is not used anywhere anymore (as `worker get` uses the worker metadata API and not the non-precise worker enumeration)