### PR TITLE
add list and get content commands of worker files

### DIFF
--- a/golem-cli/src/command.rs
+++ b/golem-cli/src/command.rs
@@ -1137,7 +1137,7 @@ pub mod worker {
             #[command(flatten)]
             worker_name: WorkerNameArg,
             /// Path to list files from (optional, defaults to root)
-            #[arg(long, short)]
+            #[arg(long)]
             path: Option<String>,
         },
         /// Get contents of a file in a worker's file system

--- a/golem-cli/src/command.rs
+++ b/golem-cli/src/command.rs
@@ -1132,6 +1132,21 @@ pub mod worker {
             /// Idempotency key of the invocation to be cancelled
             idempotency_key: IdempotencyKey,
         },
+        /// List files in a worker's file system
+        Files {
+            #[command(flatten)]
+            worker_name: WorkerNameArg,
+            /// Path to list files from (optional, defaults to root)
+            #[arg(long, short)]
+            path: Option<String>,
+        },
+        /// Get contents of a file in a worker's file system
+        FileContents {
+            #[command(flatten)]
+            worker_name: WorkerNameArg,
+            /// Path to the file to read
+            path: String,
+        },
     }
 }
 


### PR DESCRIPTION

closes #283

/claim #283

This PR implements CLI commands to list and retrieve contents of worker files, leveraging the existing REST API endpoints as requested in the bounty.

### Features Added

#### golem-cli worker files Command

  - Purpose: List files in a worker's file system
  - Usage: golem-cli worker files <WORKER_NAME> [--path <PATH>]
  - Options:
    - --path: Optional path to list files from (defaults to root /)
  - Output: Returns GetFilesResponse with detailed file metadata including names, sizes, permissions, and modification times

#### golem-cli worker file-contents Command

  - Purpose: Get contents of a specific file in a worker's file system
  - Usage: golem-cli worker file-contents <WORKER_NAME> <PATH>
  - Features:
    - Handles both UTF-8 text files and binary files gracefully
    - Outputs raw file contents directly to stdout
    - Proper error handling for missing files

### Working CLI video:

https://github.com/user-attachments/assets/25631d15-60a5-40cc-9e9f-5b8cbf313f82