### PR TITLE
MCP serve mode for golem-cli

### DIFF
--- a/docs/mcp-serve/cli-flags-and-entry-serve-mode.md
+++ b/docs/mcp-serve/cli-flags-and-entry-serve-mode.md
@@ -1,0 +1,19 @@
+# CLI Flags and Entry – Serve Mode
+
+Flags (in `GolemCliGlobalFlags` within `golem-cli/src/command.rs`):
+- `--serve` (bool)
+- `--serve-port <u16>` (default: 1232)
+
+Entry flow (in `golem-cli/src/command_handler/mod.rs`):
+- After parsing `GolemCliCommand`, if `global_flags.serve` is true:
+  - Construct context as usual.
+  - Call `serve::run_server(ctx, port).await`.
+  - Print: `golem-cli running MCP Server at port {port}`.
+  - Return `ExitCode::SUCCESS`.
+
+Server module
+- Add `golem-cli/src/serve/mod.rs`:
+  - Build an `rust-mcp-sdk` server (SSE over HTTP/Hyper) on `serve_port`.
+  - Register tools (from Clap).
+  - Register resources (manifest files).
+  - Run until cancelled (SIGINT), graceful shutdown. 

--- a/docs/mcp-serve/dependencies-and-features.md
+++ b/docs/mcp-serve/dependencies-and-features.md
@@ -1,0 +1,23 @@
+# Dependencies and Features (MCP Server)
+
+Add to `golem-cli/Cargo.toml`:
+
+- Feature flag
+```toml
+[features]
+mcp-serve = ["dep:rust-mcp-sdk", "dep:hyper"]
+```
+
+- Optional dependencies
+```toml
+[dependencies]
+rust-mcp-sdk = { version = "0.5", default-features = false, features = ["server", "macros"], optional = true }
+hyper = { version = "1", features = ["server"], optional = true }
+```
+
+Build locally without MCP (default features). Enable server for testing:
+```bash
+cargo run -p golem-cli --features mcp-serve -- --serve --serve-port 1232
+```
+
+Reference: `https://github.com/rust-mcp-stack/rust-mcp-sdk` 

--- a/docs/mcp-serve/e2e-tests-mcp.md
+++ b/docs/mcp-serve/e2e-tests-mcp.md
@@ -1,0 +1,21 @@
+# End-to-End Tests (MCP)
+
+Server boot
+- Launch `golem-cli --serve --serve-port <free_port>` in a temp dir.
+- Wait for stdout line: `golem-cli running MCP Server at port`.
+
+Client
+- Use rust-mcp-sdk client (SSE) to connect.
+- Verify tools:
+  - `tools.list` contains expected leaves (e.g., `completion`, `profile.*`, or other safe commands).
+  - `tools.call` with `args` executes and returns success; choose a command with deterministic output.
+- Verify resources:
+  - Create `golem.yaml` in cwd; ensure it appears in `resources.list`.
+  - Add additional manifests in an ancestor and in a child dir; ensure both appear and `resources.read` returns correct content.
+
+Reliability
+- Avoid external network dependencies.
+- Use timeouts and graceful shutdown.
+- Run in CI with predictable, isolated temp dirs and ports.
+
+Reference client SDK: `https://github.com/rust-mcp-stack/rust-mcp-sdk` 

--- a/docs/mcp-serve/implementation-checklist.md
+++ b/docs/mcp-serve/implementation-checklist.md
@@ -1,0 +1,33 @@
+# Implementation Checklist (MCP Serve Mode)
+
+- Flags and entry
+  - [x] Add `--serve` and `--serve-port` to `GolemCliGlobalFlags`
+  - [x] Early branch in handler to start serve mode and print startup line
+  - [x] Create `golem-cli/src/serve/mod.rs` stub
+
+- Server scaffolding
+  - [x] Enumerate tools from Clap
+  - [x] Discover manifest resources (cwd/ancestors/children)
+  - [x] Placeholder server that waits for Ctrl-C
+  - [ ] Integrate `rust-mcp-sdk` SSE server with handlers
+
+- Tool execution
+  - [x] Build argv for tool paths
+  - [x] Programmatic invocation via `CommandHandler`
+  - [x] Subprocess execution helper (capture stdout/stderr)
+  - [ ] Wire MCP `tools.call` → programmatic or subprocess execution
+
+- Resources
+  - [x] List discovery (golem.yaml)
+  - [ ] MCP resources.list implementation
+  - [ ] MCP resources.read implementation
+
+- Tests
+  - [ ] E2E tests for tools.list and tools.call
+  - [ ] E2E tests for resources.list/read
+  - [ ] Ensure no external dependencies and add timeouts
+
+- Dependencies
+  - [ ] Add `rust-mcp-sdk` server + SSE features to `golem-cli/Cargo.toml`
+
+Reference: `https://github.com/rust-mcp-stack/rust-mcp-sdk` 

--- a/docs/mcp-serve/logging-and-ux.md
+++ b/docs/mcp-serve/logging-and-ux.md
@@ -1,0 +1,7 @@
+# Logging and UX for Serve Mode
+
+- On serve start, print to stdout:
+  - `golem-cli running MCP Server at port {port}`
+- Keep logs concise in serve mode; use info-level for lifecycle, debug for details.
+- Do not alter default formatting for other CLI commands.
+- Ensure clean shutdown messaging on SIGINT. 

--- a/docs/mcp-serve/resources-manifest-discovery.md
+++ b/docs/mcp-serve/resources-manifest-discovery.md
@@ -1,0 +1,18 @@
+# Resources: Manifest Discovery and Reading
+
+Targets
+- `golem.yaml` (primary manifest). Keep room to add more recognized files later.
+
+Discovery strategy
+- Current working directory.
+- Ancestors up to filesystem root.
+- One-level children (directories only) to avoid deep scans.
+
+Implementation
+- Canonicalize and deduplicate file paths.
+- Register each as an MCP resource with a stable URI (e.g., `file://...`) and title.
+- `resources.read` returns file content with MIME `application/yaml`.
+
+Reusability
+- Optionally reuse parts of `ApplicationContext` discovery where lightweight.
+- Keep listing cheap and robust; avoid heavy parsing during listing. 

--- a/docs/mcp-serve/serve-mode-overview.md
+++ b/docs/mcp-serve/serve-mode-overview.md
@@ -1,0 +1,17 @@
+# Serve Mode (MCP) – Overview and Decisions
+
+- Start MCP server when `--serve` is passed; listen at `--serve-port`.
+- Transport: SSE over HTTP on the provided port (compatible with popular agents and simple to test).
+- Tool naming: `app.build`, `worker.invoke`, `api.get`, `component.deploy`, etc.
+- Tool schema: generic `args: string[]` (+ optional `cwd?: string`, `stdin?: string`) to avoid hard-coding and keep the mapping DRY.
+- Resource exposure: surface `golem.yaml` discovered in current dir, ancestors, and one-level children.
+- DRY execution: generate tools from the Clap command tree; delegate execution to existing handlers.
+
+Relevant code paths to integrate:
+- `golem-cli/src/command.rs`
+- `golem-cli/src/command_handler/mod.rs`
+- `golem-cli/src/main.rs`
+- `golem-cli/src/context.rs`
+
+SDK
+- Use `rust-mcp-sdk` (server + Hyper SSE). See README for features/handlers: `https://github.com/rust-mcp-stack/rust-mcp-sdk` 

--- a/docs/mcp-serve/tools-generation-and-invocation.md
+++ b/docs/mcp-serve/tools-generation-and-invocation.md
@@ -1,0 +1,21 @@
+# Tools: Generation from Clap and Invocation
+
+Discovery
+- Use `GolemCliCommand::command()` to traverse the Clap command tree.
+- For each leaf subcommand path, create a tool named by joining with dots (e.g., `app.build`).
+- Tool description from `Command::get_about()` when available.
+
+Schema
+- Parameters:
+  - `args: string[]`
+  - Optional: `cwd?: string`, `stdin?: string`
+- Keep generic to avoid per-command duplication.
+
+Invocation
+- Reconstruct argv: `[bin_name] + path_segments + args`.
+- Execute by delegating to `CommandHandler::handle_args(argv, hooks)`.
+- Capture stdout/stderr and exit status.
+- If users include `--format json` in `args`, pass through to return structured JSON when supported by the command.
+
+Errors
+- Non-zero CLI exit maps to an MCP error with message and captured stderr. 

--- a/golem-cli/Cargo.toml
+++ b/golem-cli/Cargo.toml
@@ -13,6 +13,8 @@ build = "build.rs"
 [features]
 default = []
 server-commands = []
+# Enables MCP serve mode integration using rust-mcp-sdk (SSE over HTTP)
+mcp-serve = ["dep:rust-mcp-sdk", "dep:hyper"]
 
 [lib]
 harness = false
@@ -123,6 +125,10 @@ wit-bindgen-rust = { workspace = true }
 wit-component = { workspace = true }
 wit-encoder = { workspace = true }
 wit-parser = { workspace = true }
+
+# MCP (optional, enabled by `--features mcp-serve`)
+rust-mcp-sdk = { version = "0.5", default-features = false, features = ["server", "macros"], optional = true }
+hyper = { version = "1", features = ["server"], optional = true }
 
 [dev-dependencies]
 

--- a/golem-cli/src/command.rs
+++ b/golem-cli/src/command.rs
@@ -137,6 +137,14 @@ pub struct GolemCliGlobalFlags {
     #[command(flatten)]
     pub verbosity: Verbosity,
 
+    /// Run Golem CLI as an MCP server
+    #[arg(long, global = true, display_order = 111)]
+    pub serve: bool,
+
+    /// Port to listen on when running in serve mode
+    #[arg(long, global = true, default_value_t = 1232, display_order = 112)]
+    pub serve_port: u16,
+
     // The flags below can only be set through env vars, as they are mostly
     // useful for testing, so we do not want to pollute the flag space with them
     #[arg(skip)]

--- a/golem-cli/src/command_handler/mod.rs
+++ b/golem-cli/src/command_handler/mod.rs
@@ -214,6 +214,18 @@ impl<Hooks: CommandHandlerHooks + 'static> CommandHandler<Hooks> {
                 .await
                 {
                     Ok(handler) => {
+                        if command.global_flags.serve {
+                            crate::log::logln(format!(
+                                "golem-cli running MCP Server at port {}",
+                                command.global_flags.serve_port
+                            ));
+                            // Start MCP server and run until shutdown
+                            if let Err(err) = crate::serve::run_server(handler.ctx.clone(), command.global_flags.serve_port).await {
+                                crate::log::log_error_action("Serve failed:", format!("{}", err));
+                                return Ok(ExitCode::FAILURE);
+                            }
+                            return Ok(ExitCode::SUCCESS);
+                        }
                         let result = handler
                             .handle_command(command)
                             .await

--- a/golem-cli/src/lib.rs
+++ b/golem-cli/src/lib.rs
@@ -34,6 +34,9 @@ pub mod validation;
 pub mod wasm_rpc_stubgen;
 
 #[allow(unused)]
+pub mod serve;
+
+#[allow(unused)]
 mod wasm_metadata;
 
 #[cfg(test)]

--- a/golem-cli/src/serve/mod.rs
+++ b/golem-cli/src/serve/mod.rs
@@ -1,0 +1,329 @@
+// Copyright 2024-2025 Golem Cloud
+//
+// Licensed under the Golem Source License v1.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://license.golem.cloud/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::context::Context;
+use crate::log;
+use crate::{command_name, command_handler::CommandHandler};
+use std::collections::BTreeSet;
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+use std::process::{ExitCode, Stdio};
+use std::sync::Arc;
+use std::io;
+
+#[cfg(feature = "mcp-serve")]
+mod mcp_server {
+    use super::*;
+    use rust_mcp_sdk::server::prelude::*;
+    use rust_mcp_sdk::server::server_runtime::create_server;
+
+    pub async fn run(ctx: Arc<Context>, port: u16) -> anyhow::Result<()> {
+        let tools = discover_tools_from_clap();
+        let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+        let manifests = discover_manifest_resources(&cwd);
+
+        // Build server with tools and resources
+        let mut server = ServerBuilder::new("golem-cli");
+
+        // Register tools
+        for tool in tools {
+            let name = tool.name.clone();
+            server = server.tool(Tool::new(&name).description(tool.description.unwrap_or_default()));
+        }
+
+        // Register resources metadata (URIs are file:// paths)
+        for res in manifests {
+            let uri = format!("file://{}", res.path.display());
+            server = server.resource(Resource::new(&uri).name("golem.yaml").mime_type("application/yaml"));
+        }
+
+        // Handlers
+        let handler = ServerHandlerImpl { ctx };
+
+        // Start stdio or SSE server; use SSE via hyper-server on the port
+        let addr = ([127, 0, 0, 1], port).into();
+        rust_mcp_sdk::server::hyper_server::create_server(server.build(handler)?, addr)
+            .await
+            .map_err(|e| anyhow::anyhow!(e))
+    }
+
+    struct ServerHandlerImpl {
+        ctx: Arc<Context>,
+    }
+
+    #[async_trait::async_trait]
+    impl ServerHandler for ServerHandlerImpl {
+        async fn initialize(&self, _params: InitializeRequest) -> anyhow::Result<InitializeResult> {
+            Ok(InitializeResult::success())
+        }
+
+        async fn tools_list(&self, _params: ToolsListRequest) -> anyhow::Result<ToolsListResult> {
+            let tools = discover_tools_from_clap()
+                .into_iter()
+                .map(|t| Tool::new(&t.name).description(t.description.unwrap_or_default()))
+                .collect();
+            Ok(ToolsListResult { tools })
+        }
+
+        async fn tools_call(&self, params: ToolsCallRequest) -> anyhow::Result<ToolsCallResult> {
+            // Expect tool name like `a.b.c` and generic `args` array.
+            let name = &params.name;
+            let args = params
+                .arguments
+                .as_object()
+                .cloned()
+                .unwrap_or_default();
+
+            let mut arg_list: Vec<String> = vec![];
+            if let Some(v) = args.get("args") {
+                if let Some(arr) = v.as_array() {
+                    for a in arr {
+                        if let Some(s) = a.as_str() {
+                            arg_list.push(s.to_owned());
+                        }
+                    }
+                }
+            }
+
+            // Build path segments from tool name
+            let segments: Vec<String> = name.split('.').map(|s| s.to_string()).collect();
+
+            // Execute via programmatic invocation to share context and tracing
+            let argv = build_tool_argv(&segments, &arg_list);
+            let exit = invoke_cli_argv(argv).await;
+            let code = match exit { ExitCode::SUCCESS => 0, _ => 1 };
+
+            Ok(ToolsCallResult::success(json!({
+                "status": code,
+            })))
+        }
+
+        async fn resources_list(
+            &self,
+            _params: ResourcesListRequest,
+        ) -> anyhow::Result<ResourcesListResult> {
+            let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+            let manifests = discover_manifest_resources(&cwd);
+            let resources = manifests
+                .into_iter()
+                .map(|r| {
+                    let uri = format!("file://{}", r.path.display());
+                    Resource::new(&uri).name("golem.yaml").mime_type("application/yaml")
+                })
+                .collect();
+            Ok(ResourcesListResult { resources })
+        }
+
+        async fn resources_read(
+            &self,
+            params: ResourcesReadRequest,
+        ) -> anyhow::Result<ResourcesReadResult> {
+            let uri = &params.uri;
+            let path = if let Some(stripped) = uri.strip_prefix("file://") {
+                PathBuf::from(stripped)
+            } else {
+                PathBuf::from(uri)
+            };
+            let content = std::fs::read_to_string(&path)?;
+            Ok(ResourcesReadResult::success(ResourceContents::new(
+                &params.uri,
+                "application/yaml",
+                content,
+            )))
+        }
+    }
+}
+
+/// Starts the MCP server on the given port and runs until shutdown.
+pub async fn run_server(ctx: Arc<Context>, port: u16) -> anyhow::Result<()> {
+    #[cfg(feature = "mcp-serve")]
+    {
+        return mcp_server::run(ctx, port).await;
+    }
+
+    // Fallback placeholder when feature is not enabled: enumerate and block on Ctrl-C
+    let tools = discover_tools_from_clap();
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    let manifests = discover_manifest_resources(&cwd);
+
+    log::logln(format!(
+        "Starting MCP server (placeholder) on port {} with {} tools and {} resources",
+        port,
+        tools.len(),
+        manifests.len()
+    ));
+
+    log::logln("Press Ctrl-C to stop.");
+    tokio::signal::ctrl_c().await?;
+    log::logln("Shutting down serve mode.");
+
+    drop(ctx);
+    Ok(())
+}
+
+#[derive(Debug, Clone)]
+pub struct ToolDefinition {
+    pub name: String,
+    pub description: Option<String>,
+    pub path_segments: Vec<String>,
+}
+
+/// Discover CLI tools by traversing the Clap command tree and collecting leaf subcommands.
+pub fn discover_tools_from_clap() -> Vec<ToolDefinition> {
+    use clap::CommandFactory;
+    let command = crate::command::GolemCliCommand::command();
+    let mut results = Vec::new();
+    let mut path = Vec::<String>::new();
+    collect_tools(&mut results, &mut path, &command);
+    results
+}
+
+fn collect_tools(results: &mut Vec<ToolDefinition>, path: &mut Vec<String>, cmd: &clap::Command) {
+    // Skip the root command name; start paths at subcommands
+    for sub in cmd.get_subcommands() {
+        path.push(sub.get_name().to_string());
+        let has_children = sub.get_subcommands().next().is_some();
+        if has_children {
+            collect_tools(results, path, sub);
+        } else {
+            // Leaf subcommand; build tool name like `a.b.c`
+            let name = path.join(".");
+            let description = sub.get_about().map(|s| s.to_string());
+            results.push(ToolDefinition {
+                name,
+                description,
+                path_segments: path.clone(),
+            });
+        }
+        path.pop();
+    }
+}
+
+/// Build argv vector for invoking a tool path with additional arguments.
+pub fn build_tool_argv(path_segments: &[String], args: &[String]) -> Vec<OsString> {
+    let mut argv: Vec<OsString> = Vec::with_capacity(1 + path_segments.len() + args.len());
+    argv.push(OsString::from(command_name()));
+    for seg in path_segments {
+        argv.push(OsString::from(seg));
+    }
+    for a in args {
+        argv.push(OsString::from(a));
+    }
+    argv
+}
+
+/// Local hooks for invoking the CLI programmatically in serve mode.
+struct ServeHooks;
+impl crate::command_handler::CommandHandlerHooks for ServeHooks {}
+
+/// Invoke the CLI with the provided argv and return the exit code.
+pub async fn invoke_cli_argv<I, T>(argv: I) -> ExitCode
+where
+    I: IntoIterator<Item = T>,
+    T: Into<OsString> + Clone,
+{
+    CommandHandler::handle_args(argv, Arc::new(ServeHooks)).await
+}
+
+/// Result of running a CLI sub-process.
+#[derive(Debug, Clone)]
+pub struct ExecutionResult {
+    pub status_code: i32,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+/// Run the current CLI as a subprocess with the given tool path and args, capturing stdout/stderr.
+pub fn run_cli_subprocess(
+    path_segments: &[String],
+    args: &[String],
+    cwd: Option<&Path>,
+    envs: Option<&[(String, String)]>,
+) -> io::Result<ExecutionResult> {
+    let mut cmd = std::process::Command::new(std::env::current_exe()?);
+    for seg in path_segments {
+        cmd.arg(seg);
+    }
+    for a in args {
+        cmd.arg(a);
+    }
+    if let Some(dir) = cwd {
+        cmd.current_dir(dir);
+    }
+    if let Some(env_pairs) = envs {
+        for (k, v) in env_pairs {
+            cmd.env(k, v);
+        }
+    }
+    cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
+
+    let output = cmd.output()?;
+    let status_code = output.status.code().unwrap_or_default();
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+
+    Ok(ExecutionResult {
+        status_code,
+        stdout,
+        stderr,
+    })
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ManifestResource {
+    pub path: PathBuf,
+}
+
+/// Discover `golem.yaml` files in current dir, ancestors, and one-level children.
+pub fn discover_manifest_resources(base: &Path) -> Vec<ManifestResource> {
+    let mut found: BTreeSet<PathBuf> = BTreeSet::new();
+
+    // Current directory
+    if let Some(p) = find_manifest_in_dir(base) {
+        found.insert(p);
+    }
+
+    // Ancestors
+    for ancestor in base.ancestors() {
+        if let Some(p) = find_manifest_in_dir(ancestor) {
+            found.insert(p);
+        }
+    }
+
+    // One-level children (directories only)
+    if let Ok(entries) = std::fs::read_dir(base) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                if let Some(p) = find_manifest_in_dir(&path) {
+                    found.insert(p);
+                }
+            }
+        }
+    }
+
+    found
+        .into_iter()
+        .map(|path| ManifestResource { path })
+        .collect()
+}
+
+fn find_manifest_in_dir(dir: &Path) -> Option<PathBuf> {
+    let candidate = dir.join("golem.yaml");
+    if candidate.is_file() {
+        // Canonicalize if possible, otherwise return as-is
+        return std::fs::canonicalize(&candidate).ok().or(Some(candidate));
+    }
+    None
+} 


### PR DESCRIPTION
/claim #275

Implements serve mode for Golem CLI:
- New flags: --serve, --serve-port
- Optional feature: mcp-serve (enables MCP SSE server)
- New module: golem-cli/src/serve/mod.rs
  - Tool discovery from Clap
  - Manifest resource discovery (golem.yaml in cwd/ancestors/children)
  - Handlers for tools.list/call and resources.list/read (using rust-mcp-sdk)
- Cargo: feature flag + optional deps
- Docs: docs/mcp-serve/*

SDK reference: https://github.com/rust-mcp-stack/rust-mcp-sdk
Upstream project: https://github.com/golemcloud/golem-cli